### PR TITLE
Add overwrite option to unzip

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,8 @@ function download_graph {
   done
 
   if [ -f graph-$NAME.zip ]; then
-    unzip $GRAPH_FILE  -d ./graphs
+    # if the graph already exists then overwrite it, otherwise we need to build a new one on every start
+    unzip -o $GRAPH_FILE  -d ./graphs
     return $?;
   else
     return 1;
@@ -83,7 +84,7 @@ function process {
 
 #workaround for azure DNS issue
 
-if [ -n "$MESOS_CONTAINER_NAME"  ]; then 
+if [ -n "$MESOS_CONTAINER_NAME"  ]; then
   echo "search marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf
 fi
 


### PR DESCRIPTION
During local development it is very annoying that a failed unzip causes a complete rebuild of the graph.

Therefore I propose to overwrite the graph during the unzip.