### PR TITLE
Encrypt route URLs returned by the API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,10 @@
                 <!-- Fixes issue with tests failing in some environments. Replace this when proper version of 3.0 is released. -->
                 <version>3.0.0-M3</version>
                 <configuration>
+                    <forkCount>2</forkCount>
+                    <environmentVariables>
+                        <ENCRYPTION_SECRET_KEY>very secret key</ENCRYPTION_SECRET_KEY>
+                    </environmentVariables>
                     <argLine>-Xms5G</argLine>
                     <argLine>-Xmx5G</argLine>
                     <argLine>-XX:NewRatio=5</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,6 @@
                 <!-- Fixes issue with tests failing in some environments. Replace this when proper version of 3.0 is released. -->
                 <version>3.0.0-M3</version>
                 <configuration>
-                    <argLine>-XX:+UseParNewGC</argLine>
                     <argLine>-Xms5G</argLine>
                     <argLine>-Xmx5G</argLine>
                     <argLine>-XX:NewRatio=5</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,7 @@
                     <forkCount>2</forkCount>
                     <environmentVariables>
                         <ENCRYPTION_SECRET_KEY>very secret key</ENCRYPTION_SECRET_KEY>
+                        <API_URL>https://secret.org/api/</API_URL>
                     </environmentVariables>
                     <argLine>-Xms5G</argLine>
                     <argLine>-Xmx5G</argLine>

--- a/src/main/java/org/opentripplanner/api/common/Crypto.java
+++ b/src/main/java/org/opentripplanner/api/common/Crypto.java
@@ -1,0 +1,56 @@
+package org.opentripplanner.api.common;
+
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+
+public class Crypto {
+
+    private static SecretKeySpec keySpec;
+    private static final Logger LOG = LoggerFactory.getLogger(Crypto.class);
+
+    static {
+
+        String secretKey = Optional.ofNullable(System.getenv("ENCRYPTION_SECRET_KEY"))
+                .filter(s -> !s.trim().isEmpty())
+                .orElseGet(() -> {
+                    LOG.error("No environment variable ENCRYPTION_SECRET_KEY defined! Falling back on default secret key!");
+                    return "very secret key";
+                });
+
+        MessageDigest sha;
+        try {
+            sha = MessageDigest.getInstance("SHA-256");
+            byte[] keyBytes = sha.digest(secretKey.getBytes(StandardCharsets.UTF_8));
+            keySpec = new SecretKeySpec(keyBytes, "AES");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Cipher getCipher() throws NoSuchPaddingException, NoSuchAlgorithmException {
+        return Cipher.getInstance("AES/ECB/PKCS5Padding");
+    }
+
+    public static String encrypt(String plainText) throws GeneralSecurityException {
+        Cipher cipher = getCipher();
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+        byte[] encrypted = cipher.doFinal(plainText.getBytes());
+        return Base64.encodeBase64URLSafeString(encrypted);
+    }
+
+    public static String decrypt(String cipherText) throws GeneralSecurityException {
+        Cipher cipher = getCipher();
+        cipher.init(Cipher.DECRYPT_MODE, keySpec);
+        return new String(cipher.doFinal(Base64.decodeBase64(cipherText)));
+    }
+}

--- a/src/main/java/org/opentripplanner/api/common/Crypto.java
+++ b/src/main/java/org/opentripplanner/api/common/Crypto.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.api.common;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +30,8 @@ public class Crypto {
         String secretKey = Optional.ofNullable(System.getenv("ENCRYPTION_SECRET_KEY"))
                 .filter(s -> !s.trim().isEmpty())
                 .orElseGet(() -> {
-                    LOG.error("No environment variable ENCRYPTION_SECRET_KEY defined! Falling back on default secret key!");
-                    return "very secret key";
+                    LOG.error("No environment variable ENCRYPTION_SECRET_KEY defined! Falling back on a random secret key. This means that your redirect URLs will be invalid after restarting OTP.");
+                    return RandomStringUtils.random(64);
                 });
 
         MessageDigest sha;
@@ -39,7 +40,7 @@ public class Crypto {
             byte[] keyBytes = sha.digest(secretKey.getBytes(StandardCharsets.UTF_8));
             keySpec = new SecretKeySpec(keyBytes, "AES");
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            LOG.error("Could not initialise encryption library.", e);
         }
     }
 

--- a/src/main/java/org/opentripplanner/api/common/Crypto.java
+++ b/src/main/java/org/opentripplanner/api/common/Crypto.java
@@ -14,8 +14,6 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 public class Crypto {
@@ -73,7 +71,7 @@ public class Crypto {
         return encrypt(withSeparator);
     }
 
-    static class DecryptionResult {
+    public static class DecryptionResult {
 
         public final OffsetDateTime expiry;
         public final String plainText;

--- a/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
+++ b/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
@@ -16,6 +16,8 @@ import java.time.OffsetDateTime;
 @Path("/redirect/{cipherText}")
 public class EncryptedRedirect {
 
+    public static String REDIRECT_PATH = "/otp/redirect/";
+
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
     public static Response redirect(@PathParam("cipherText") String cipherText) {

--- a/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
+++ b/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.api.resource;
+
+import org.opentripplanner.api.common.Crypto;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.time.OffsetDateTime;
+
+@Path("/redirect/{cipherText}")
+public class EncryptedRedirect {
+
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON })
+    public static Response redirect(@PathParam("cipherText") String cipherText) {
+        try {
+            Crypto.DecryptionResult res = Crypto.decryptWithExpiry(cipherText);
+            if(res.expiry.isBefore(OffsetDateTime.now())){
+                return Response.temporaryRedirect(new URI(res.plainText)).build();
+            } else return Response.serverError().build();
+        } catch (GeneralSecurityException | URISyntaxException e) {
+            return Response.serverError().build();
+        }
+    }
+
+}

--- a/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
+++ b/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
@@ -12,11 +12,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
 @Path("/redirect/{cipherText}")
 public class EncryptedRedirect {
 
-    public static String REDIRECT_PATH = "/otp/redirect/";
+    public static String API_URL = Optional.ofNullable(System.getenv("API_URL")).filter(s -> !s.trim().isEmpty()).orElse("").replaceAll("/$","");
+    public static String REDIRECT_PREFIX = API_URL + "/redirect/";
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })

--- a/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
+++ b/src/main/java/org/opentripplanner/api/resource/EncryptedRedirect.java
@@ -21,11 +21,11 @@ public class EncryptedRedirect {
     public static Response redirect(@PathParam("cipherText") String cipherText) {
         try {
             Crypto.DecryptionResult res = Crypto.decryptWithExpiry(cipherText);
-            if(res.expiry.isBefore(OffsetDateTime.now())){
+            if(res.expiry.isAfter(OffsetDateTime.now())){
                 return Response.temporaryRedirect(new URI(res.plainText)).build();
-            } else return Response.serverError().build();
+            } else return Response.status(Response.Status.FORBIDDEN).entity("URL redirect has expired.").build();
         } catch (GeneralSecurityException | URISyntaxException e) {
-            return Response.serverError().build();
+            return Response.serverError().entity(e.getMessage()).build();
         }
     }
 

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -2,6 +2,7 @@
 package org.opentripplanner.model;
 
 import org.opentripplanner.api.common.Crypto;
+import org.opentripplanner.api.resource.EncryptedRedirect;
 
 import java.security.GeneralSecurityException;
 import java.time.OffsetDateTime;
@@ -94,7 +95,7 @@ public final class Route extends IdentityBean<FeedScopedId> {
     public String getUrl() {
         if(url != null) {
             String cipherText = Crypto.encryptWithExpiry(url, OffsetDateTime.now().plusMinutes(15));
-            return "/otp/redirect/" + cipherText;
+            return EncryptedRedirect.REDIRECT_PATH + cipherText;
         }
         return url;
     }

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -4,7 +4,6 @@ package org.opentripplanner.model;
 import org.opentripplanner.api.common.Crypto;
 import org.opentripplanner.api.resource.EncryptedRedirect;
 
-import java.security.GeneralSecurityException;
 import java.time.OffsetDateTime;
 
 public final class Route extends IdentityBean<FeedScopedId> {
@@ -95,7 +94,7 @@ public final class Route extends IdentityBean<FeedScopedId> {
     public String getUrl() {
         if(url != null) {
             String cipherText = Crypto.encryptWithExpiry(url, OffsetDateTime.now().plusMinutes(15));
-            return EncryptedRedirect.REDIRECT_PATH + cipherText;
+            return EncryptedRedirect.REDIRECT_PREFIX + cipherText;
         }
         return url;
     }

--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -1,6 +1,11 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import org.opentripplanner.api.common.Crypto;
+
+import java.security.GeneralSecurityException;
+import java.time.OffsetDateTime;
+
 public final class Route extends IdentityBean<FeedScopedId> {
 
     private static final long serialVersionUID = 1L;
@@ -87,6 +92,10 @@ public final class Route extends IdentityBean<FeedScopedId> {
     }
 
     public String getUrl() {
+        if(url != null) {
+            String cipherText = Crypto.encryptWithExpiry(url, OffsetDateTime.now().plusMinutes(15));
+            return "/otp/redirect/" + cipherText;
+        }
         return url;
     }
 

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -93,6 +93,7 @@ public class OTPApplication extends Application {
             UpdaterStatusResource.class,
             ScenarioResource.class,
             RepeatedRaptorTestResource.class,
+            EncryptedRedirect.class,
             /* Features and Filters: extend Jersey, manipulate requests and responses. */
             CorsFilter.class,
             MultiPartFeature.class

--- a/src/test/java/org/opentripplanner/api/common/CryptoTest.java
+++ b/src/test/java/org/opentripplanner/api/common/CryptoTest.java
@@ -1,0 +1,19 @@
+package org.opentripplanner.api.common;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CryptoTest {
+    @Test
+    public void shouldEncryptAndDecrypt() throws Exception {
+        String plainText = "Roxanne! You don't need to put out the red light!";
+        String cipherText = Crypto.encrypt(plainText);
+
+        assertThat(cipherText, is("zal31JId-7PA4zSWSlhququ6b5jogbdqUHE1-QTaCdeuONKTo4Zj8-fmvNPTKcdW4Dv1KYDQuNsq6OI3abC8SA"));
+
+        assertThat(Crypto.decrypt(cipherText), is(plainText));
+    }
+
+}

--- a/src/test/java/org/opentripplanner/api/common/CryptoTest.java
+++ b/src/test/java/org/opentripplanner/api/common/CryptoTest.java
@@ -33,6 +33,15 @@ public class CryptoTest {
 
         assertThat(result.expiry.isEqual(expiry), is(true));
         assertThat(result.plainText, is(plainText));
+    }
 
+    @Test
+    public void shouldDecryptUrls() throws Exception {
+        String cipherText = "iHZUunQLPB_iGqxydlOUb-uwA7EjBpxzHJOpuCNUjBpKfVg7MljdxM2QiRz_i0zt4eqHMCVLj6u8d1lYApjssw";
+
+        Crypto.DecryptionResult result = Crypto.decryptWithExpiry(cipherText);
+
+        assertThat(result.expiry.toString(), is("2020-02-17T17:48:08Z"));
+        assertThat(result.plainText, is("https://de.wikipedia.org/wiki/Mitfahrzentrale"));
     }
 }

--- a/src/test/java/org/opentripplanner/api/common/CryptoTest.java
+++ b/src/test/java/org/opentripplanner/api/common/CryptoTest.java
@@ -2,13 +2,19 @@ package org.opentripplanner.api.common;
 
 import org.junit.Test;
 
+import java.time.OffsetDateTime;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CryptoTest {
+
+    OffsetDateTime expiry = OffsetDateTime.parse("2020-02-17T17:04:55+01:00");
+
+    String plainText = "Roxanne! You don't need to put out the red light!";
+
     @Test
     public void shouldEncryptAndDecrypt() throws Exception {
-        String plainText = "Roxanne! You don't need to put out the red light!";
         String cipherText = Crypto.encrypt(plainText);
 
         assertThat(cipherText, is("zal31JId-7PA4zSWSlhququ6b5jogbdqUHE1-QTaCdeuONKTo4Zj8-fmvNPTKcdW4Dv1KYDQuNsq6OI3abC8SA"));
@@ -16,4 +22,17 @@ public class CryptoTest {
         assertThat(Crypto.decrypt(cipherText), is(plainText));
     }
 
+    @Test
+    public void shouldEncryptAndDecryptWithExpiry() throws Exception {
+        String cipherText = Crypto.encryptWithExpiry(plainText, expiry);
+
+        assertThat(cipherText, is("zal31JId-7PA4zSWSlhququ6b5jogbdqUHE1-QTaCdeuONKTo4Zj8-fmvNPTKcdW0vBJuQgEn_U-nn0E0HpnzewlNqjOsEQTBMKJDPRqW1w"));
+        assertThat(Crypto.decrypt(cipherText), is("Roxanne! You don't need to put out the red light!___-___1581955495"));
+
+        Crypto.DecryptionResult result = Crypto.decryptWithExpiry(cipherText);
+
+        assertThat(result.expiry.isEqual(expiry), is(true));
+        assertThat(result.plainText, is(plainText));
+
+    }
 }

--- a/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.gtfs.mapping;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
@@ -8,11 +9,8 @@ import org.onebusaway.gtfs.model.Route;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.*;
 
 public class RouteMapperTest {
 
@@ -81,7 +79,7 @@ public class RouteMapperTest {
         assertEquals(LONG_NAME, result.getLongName());
         assertEquals(DESC, result.getDesc());
         assertEquals(TYPE, result.getType());
-        assertEquals(URL, result.getUrl());
+        assertThat(result.getUrl(), startsWith("/otp/redirect/EofieChH7Rc0IBy1S"));
         assertEquals(COLOR, result.getColor());
         assertEquals(TEXT_COLOR, result.getTextColor());
         assertEquals(BIKES_ALLOWED, result.getBikesAllowed());

--- a/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/RouteMapperTest.java
@@ -79,7 +79,7 @@ public class RouteMapperTest {
         assertEquals(LONG_NAME, result.getLongName());
         assertEquals(DESC, result.getDesc());
         assertEquals(TYPE, result.getType());
-        assertThat(result.getUrl(), startsWith("/otp/redirect/EofieChH7Rc0IBy1S"));
+        assertThat(result.getUrl(), startsWith("https://secret.org/api/redirect/EofieChH7Rc0IBy1S"));
         assertEquals(COLOR, result.getColor());
         assertEquals(TEXT_COLOR, result.getTextColor());
         assertEquals(BIKES_ALLOWED, result.getBikesAllowed());


### PR DESCRIPTION
This is because we want to not return the raw carpool URLs but hand out encrypted ones which have to go through a tightly controlled and rate limited endpoint.

This is to avoid someone crawling all the URLs and being able to derive peoples movements. 

Fixes #12