### PR TITLE
Add separate no-through traffic for bicycles

### DIFF
--- a/src/main/java/org/opentripplanner/common/StreetUtils.java
+++ b/src/main/java/org/opentripplanner/common/StreetUtils.java
@@ -133,7 +133,7 @@ public class StreetUtils {
     }
 
     private static void collectNeighbourVertices(
-        Graph graph, Map<Vertex, ArrayList<Vertex>> neighborsForVertex, boolean noThruTraffic) {
+        Graph graph, Map<Vertex, ArrayList<Vertex>> neighborsForVertex, boolean motorVehicleNoThruTraffic) {
 
         // RoutingRequest options = new RoutingRequest(new TraverseModeSet(TraverseMode.WALK, TraverseMode.TRANSIT));
         RoutingRequest options = new RoutingRequest(new TraverseModeSet(TraverseMode.WALK));
@@ -149,7 +149,7 @@ public class StreetUtils {
                       e instanceof ElevatorEdge || e instanceof FreeEdge)) {
                     continue;
                 }
-                if ((e instanceof StreetEdge && ((StreetEdge)e).isNoThruTraffic()) != noThruTraffic) {
+                if ((e instanceof StreetEdge && ((StreetEdge)e).isMotorVehicleNoThruTraffic()) != motorVehicleNoThruTraffic) {
                     continue;
                 }
                 State s1 = e.traverse(s0);
@@ -231,7 +231,7 @@ public class StreetUtils {
                         if (!isolated.containsKey(e)) {
                             // not a true island edge but has limited access
                             // so convert to noThruTraffic
-                            pse.setNoThruTraffic(true);
+                            pse.setMotorVehicleNoThruTraffic(true);
                             stats.put("noThru", stats.get("noThru") + 1);
                         } else {
                             StreetTraversalPermission permission = pse.getPermission();

--- a/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/osm/OpenStreetMapModule.java
@@ -699,7 +699,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                                         WayProperties wayData, OSMWithTags way) {
 
             Set<T2<Alert, NoteMatcher>> notes = wayPropertySet.getNoteForWay(way);
-            boolean noThruTraffic = way.isThroughTrafficExplicitlyDisallowed();
+            boolean motorVehicleNoThrough = way.isMotorVehicleThroughTrafficExplicitlyDisallowed();
+            boolean bicycleNoThrough = way.isBicycleNoThroughTrafficExplicitlyDisallowed();
             // if (noThruTraffic) LOG.info("Way {} does not allow through traffic.", way.getId());
             if (street != null) {
                 double safety = wayData.getSafetyFeatures().first;
@@ -711,7 +712,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     for (T2<Alert, NoteMatcher> note : notes)
                         graph.streetNotesService.addStaticNote(street, note.first, note.second);
                 }
-                street.setNoThruTraffic(noThruTraffic);
+                street.setMotorVehicleNoThruTraffic(motorVehicleNoThrough);
+                street.setBicycleNoThruTraffic(bicycleNoThrough);
             }
 
             if (backStreet != null) {
@@ -724,7 +726,8 @@ public class OpenStreetMapModule implements GraphBuilderModule {
                     for (T2<Alert, NoteMatcher> note : notes)
                         graph.streetNotesService.addStaticNote(backStreet, note.first, note.second);
                 }
-                backStreet.setNoThruTraffic(noThruTraffic);
+                backStreet.setMotorVehicleNoThruTraffic(motorVehicleNoThrough);
+                backStreet.setBicycleNoThruTraffic(bicycleNoThrough);
             }
         }
 

--- a/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
+++ b/src/main/java/org/opentripplanner/inspector/TraversalPermissionsEdgeRenderer.java
@@ -46,8 +46,11 @@ public class TraversalPermissionsEdgeRenderer implements EdgeVertexRenderer {
                 attrs.color = getColor(pse.getPermission());
                 attrs.label = getLabel(pse.getPermission());
             }
-            if(pse.isNoThruTraffic()) {
-                attrs.label+=" NTT";
+            if(pse.isMotorVehicleNoThruTraffic()) {
+                attrs.label+=" motor NTT";
+            }
+            if(pse.isBicycleNoThruTraffic()) {
+                attrs.label+=" bicycle NTT";
             }
         } else if (e instanceof StreetTransitLink) {
             attrs.color = LINK_COLOR_EDGE;

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -280,16 +280,28 @@ public class OSMWithTags {
     }
 
     /**
-     * Returns true if through traffic is not allowed.
+     * Returns true if through traffic for motor vehicles is not allowed.
      * 
      * @return
      */
-    public boolean isThroughTrafficExplicitlyDisallowed() {
-        String access = getTag("access");
+    public boolean isMotorVehicleThroughTrafficExplicitlyDisallowed() {
         String motorVehicle = getTag("motor_vehicle");
+        return isGeneralNoThroughTraffic() || "destination".equals(motorVehicle);
+    }
+    /**
+     * Returns true if through traffic for bicycle is not allowed.
+     *
+     * @return
+     */
+    public boolean isBicycleNoThroughTrafficExplicitlyDisallowed() {
+        String bicycle = getTag("bicycle");
+        return isGeneralNoThroughTraffic() || "destination".equals(bicycle);
+    }
+
+    private boolean isGeneralNoThroughTraffic() {
+        String access = getTag("access");
         return "destination".equals(access) || "private".equals(access)
-                || "customers".equals(access) || "delivery".equals(access)
-                || "destination".equals(motorVehicle);
+                || "customers".equals(access) || "delivery".equals(access);
     }
     
     /**

--- a/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
+++ b/src/main/java/org/opentripplanner/openstreetmap/model/OSMWithTags.java
@@ -286,8 +286,10 @@ public class OSMWithTags {
      */
     public boolean isThroughTrafficExplicitlyDisallowed() {
         String access = getTag("access");
+        String motorVehicle = getTag("motor_vehicle");
         return "destination".equals(access) || "private".equals(access)
-                || "customers".equals(access) || "delivery".equals(access);
+                || "customers".equals(access) || "delivery".equals(access)
+                || "destination".equals(motorVehicle);
     }
     
     /**

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -877,8 +877,11 @@ public class State implements Cloneable {
         return getElapsedTimeSeconds() - stateData.initialWaitTime;
     }
 
-    public boolean hasEnteredNoThruTrafficArea() {
-        return stateData.enteredNoThroughTrafficArea;
+    public boolean hasEnteredMotorVehicleNoThruTrafficArea() {
+        return stateData.enteredMotorVehicleNoThroughTrafficArea;
     }
 
+    public boolean hasEnteredBicycleNoThruTrafficArea() {
+        return stateData.enteredBicycleNoThroughTrafficArea;
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -87,7 +87,8 @@ public class StateData implements Cloneable {
     public Set<String> bikeRentalNetworks;
 
     /* This boolean is set to true upon transition from a normal street to a no-through-traffic street. */
-    protected boolean enteredNoThroughTrafficArea;
+    protected boolean enteredMotorVehicleNoThroughTrafficArea;
+    protected boolean enteredBicycleNoThroughTrafficArea;
 
     public StateData(RoutingRequest options) {
         TraverseModeSet modes = options.modes;

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -266,10 +266,14 @@ public class StateEditor {
         child.stateData.previousTrip = previousTrip;
     }
 
-    public void setEnteredNoThroughTrafficArea() {
-        child.stateData.enteredNoThroughTrafficArea = true;
+    public void setEnteredMotorVerhicleNoThroughTrafficArea() {
+        child.stateData.enteredMotorVehicleNoThroughTrafficArea = true;
     }
-    
+
+    public void setEnteredBicycleNoThroughTrafficArea() {
+        child.stateData.enteredBicycleNoThroughTrafficArea= true;
+    }
+
     /**
      * Initial wait time is recorded so it can be subtracted out of paths in lieu of "reverse optimization".
      * This happens in Analyst.
@@ -552,8 +556,11 @@ public class StateEditor {
         child.stateData.bikeRentalNetworks = networks;
     }
 
-    public boolean hasEnteredNoThroughTrafficArea() {
-        return child.hasEnteredNoThruTrafficArea();
+    public boolean hasEnteredMotorVehicleNoThroughTrafficArea() {
+        return child.hasEnteredMotorVehicleNoThruTrafficArea();
     }
 
+    public boolean hasEnteredBicycleNoThroughTrafficArea() {
+        return child.hasEnteredBicycleNoThruTrafficArea();
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -59,10 +59,11 @@ public class StreetEdge extends Edge implements Cloneable {
     private static final int BACK_FLAG_INDEX = 0;
     private static final int ROUNDABOUT_FLAG_INDEX = 1;
     private static final int HASBOGUSNAME_FLAG_INDEX = 2;
-    private static final int NOTHRUTRAFFIC_FLAG_INDEX = 3;
+    private static final int MOTOR_VEHICLE_NOTHRUTRAFFIC = 3;
     private static final int STAIRS_FLAG_INDEX = 4;
     private static final int SLOPEOVERRIDE_FLAG_INDEX = 5;
     private static final int WHEELCHAIR_ACCESSIBLE_FLAG_INDEX = 6;
+    private static final int BICYCLE_NOTHRUTRAFFIC = 7;
 
     /** back, roundabout, stairs, ... */
     private byte flags;
@@ -397,28 +398,8 @@ public class StreetEdge extends Edge implements Cloneable {
         StateEditor s1 = s0.edit(this);
         s1.setBackMode(traverseMode);
         s1.setBackWalkingBike(walkingBike);
-
-        /* Handle no through traffic areas. */
-        if (!s0.getReverseOptimizing()) {
-            if (this.isNoThruTraffic()) {
-                // Record transition into no-through-traffic area.
-                if (backEdge instanceof StreetEdge && !((StreetEdge) backEdge).isNoThruTraffic()) {
-                    s1.setEnteredNoThroughTrafficArea();
-                }
-                // If we transitioned into a no-through-traffic area at some point, check if we are exiting it.
-                if (s1.hasEnteredNoThroughTrafficArea()) {
-                    // Only Edges are marked as no-thru, but really we need to avoid creating dominant, pruned states
-                    // on thru _Vertices_. This could certainly be improved somehow.
-                    for (StreetEdge se : Iterables.filter(s1.getVertex().getOutgoing(), StreetEdge.class)) {
-                        if (!se.isNoThruTraffic()) {
-
-                            // This vertex has at least one through-traffic edge. We can't dominate it with a no-thru state.
-                            return null;
-                        }
-                    }
-                }
-            }
-        }
+        if (handleMotorVehicleNoThroughTraffic(s0, traverseMode, backEdge, s1)) return null;
+        if (handleBicycleNoThroughTraffic(s0, traverseMode, backEdge, s1)) return null;
 
         int roundedTime = (int) Math.ceil(time);
 
@@ -527,6 +508,55 @@ public class StreetEdge extends Edge implements Cloneable {
         return s1;
     }
 
+    private boolean handleMotorVehicleNoThroughTraffic(State s0, TraverseMode traverseMode, Edge backEdge, StateEditor s1) {
+        /* Handle no through traffic areas. */
+        if (!s0.getReverseOptimizing() && traverseMode.isDriving()) {
+            if (this.isMotorVehicleNoThruTraffic()) {
+                // Record transition into no-through-traffic area.
+                if (backEdge instanceof StreetEdge && !((StreetEdge) backEdge).isMotorVehicleNoThruTraffic()) {
+                    s1.setEnteredMotorVerhicleNoThroughTrafficArea();
+                }
+                // If we transitioned into a no-through-traffic area at some point, check if we are exiting it.
+                if (s1.hasEnteredMotorVehicleNoThroughTrafficArea()) {
+                    // Only Edges are marked as no-thru, but really we need to avoid creating dominant, pruned states
+                    // on thru _Vertices_. This could certainly be improved somehow.
+                    for (StreetEdge se : Iterables.filter(s1.getVertex().getOutgoing(), StreetEdge.class)) {
+                        if (!se.isMotorVehicleNoThruTraffic()) {
+
+                            // This vertex has at least one through-traffic edge. We can't dominate it with a no-thru state.
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean handleBicycleNoThroughTraffic(State s0, TraverseMode traverseMode, Edge backEdge, StateEditor s1) {
+        /* Handle no through traffic areas. */
+        if (!s0.getReverseOptimizing() && traverseMode.isCycling()) {
+            if (this.isBicycleNoThruTraffic()) {
+                // Record transition into no-through-traffic area.
+                if (backEdge instanceof StreetEdge && !((StreetEdge) backEdge).isBicycleNoThruTraffic()) {
+                    s1.setEnteredMotorVerhicleNoThroughTrafficArea();
+                }
+                // If we transitioned into a no-through-traffic area at some point, check if we are exiting it.
+                if (s1.hasEnteredMotorVehicleNoThroughTrafficArea()) {
+                    // Only Edges are marked as no-thru, but really we need to avoid creating dominant, pruned states
+                    // on thru _Vertices_. This could certainly be improved somehow.
+                    for (StreetEdge se : Iterables.filter(s1.getVertex().getOutgoing(), StreetEdge.class)) {
+                        if (!se.isBicycleNoThruTraffic()) {
+                            // This vertex has at least one through-traffic edge. We can't dominate it with a no-thru state.
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     private double calculateOverageWeight(double firstValue, double secondValue, double maxValue,
             double softPenalty, double overageRate) {
         // apply penalty if we stepped over the limit on this traversal
@@ -605,7 +635,8 @@ public class StreetEdge extends Edge implements Cloneable {
     public String toString() {
         return "StreetEdge(" + getId() + ", " + name + ", " + fromv + " -> " + tov
                 + " length=" + this.getDistance() + " carSpeed=" + this.getCarSpeed()
-                + " permission=" + this.getPermission() + " ref=" + this.getRef() + " NTT=" + this.isNoThruTraffic() + ")";
+                + " permission=" + this.getPermission() + " ref=" + this.getRef() + " motorVehicleNoThrough="
+                + this.isMotorVehicleNoThruTraffic() + "bicycleNoThrough=\"" + this.isMotorVehicleNoThruTraffic() + ")";
     }
 
     @Override
@@ -737,13 +768,21 @@ public class StreetEdge extends Edge implements Cloneable {
 	    flags = BitSetUtils.set(flags, HASBOGUSNAME_FLAG_INDEX, hasBogusName);
 	}
 
-	public boolean isNoThruTraffic() {
-            return BitSetUtils.get(flags, NOTHRUTRAFFIC_FLAG_INDEX);
+	public boolean isMotorVehicleNoThruTraffic() {
+            return BitSetUtils.get(flags, MOTOR_VEHICLE_NOTHRUTRAFFIC);
 	}
 
-	public void setNoThruTraffic(boolean noThruTraffic) {
-	    flags = BitSetUtils.set(flags, NOTHRUTRAFFIC_FLAG_INDEX, noThruTraffic);
+	public void setMotorVehicleNoThruTraffic(boolean noThruTraffic) {
+	    flags = BitSetUtils.set(flags, MOTOR_VEHICLE_NOTHRUTRAFFIC, noThruTraffic);
 	}
+
+    public boolean isBicycleNoThruTraffic() {
+        return BitSetUtils.get(flags, BICYCLE_NOTHRUTRAFFIC);
+    }
+
+    public void setBicycleNoThruTraffic(boolean noThruTraffic) {
+        flags = BitSetUtils.set(flags, BICYCLE_NOTHRUTRAFFIC, noThruTraffic);
+    }
 
 	/**
 	 * This street is a staircase
@@ -866,11 +905,13 @@ public class StreetEdge extends Edge implements Cloneable {
         } else {
             if (((TemporarySplitterVertex) v).isEndVertex()) {
                 e1 = new TemporaryPartialStreetEdge(this, (StreetVertex) fromv, v, geoms.first, name);
-                e1.setNoThruTraffic(this.isNoThruTraffic());
+                e1.setMotorVehicleNoThruTraffic(this.isMotorVehicleNoThruTraffic());
+                e1.setBicycleNoThruTraffic(this.isBicycleNoThruTraffic());
                 e1.setStreetClass(this.getStreetClass());
             } else {
                 e2 = new TemporaryPartialStreetEdge(this, v, (StreetVertex) tov, geoms.second, name);
-                e2.setNoThruTraffic(this.isNoThruTraffic());
+                e2.setMotorVehicleNoThruTraffic(this.isMotorVehicleNoThruTraffic());
+                e2.setBicycleNoThruTraffic(this.isBicycleNoThruTraffic());
                 e2.setStreetClass(this.getStreetClass());
             }
         }

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -21,7 +21,6 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.location.TemporaryStreetLocation;
 import org.opentripplanner.routing.services.StreetVertexIndexService;
-import org.opentripplanner.routing.util.ElevationUtils;
 import org.opentripplanner.routing.vertextype.SampleVertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
@@ -175,14 +174,16 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
             TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(
                     street, fromv, base, geometries.first, name, lengthIn);
 
-            temporaryPartialStreetEdge.setNoThruTraffic(street.isNoThruTraffic());
+            temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
+            temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
             temporaryPartialStreetEdge.setStreetClass(street.getStreetClass());
         } else {
             TemporaryPartialStreetEdge temporaryPartialStreetEdge = new TemporaryPartialStreetEdge(
                     street, base, tov, geometries.second, name, lengthOut);
 
             temporaryPartialStreetEdge.setStreetClass(street.getStreetClass());
-            temporaryPartialStreetEdge.setNoThruTraffic(street.isNoThruTraffic());
+            temporaryPartialStreetEdge.setMotorVehicleNoThruTraffic(street.isMotorVehicleNoThruTraffic());
+            temporaryPartialStreetEdge.setBicycleNoThruTraffic(street.isBicycleNoThruTraffic());
         }
     }
 

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
@@ -214,7 +214,7 @@ public class TestStreetMatcher {
         }
 
         @Override
-        public boolean isNoThruTraffic() {
+        public boolean isMotorVehicleNoThruTraffic() {
             return false;
         }
 

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
@@ -120,6 +120,10 @@ public class OSMWithTagsTest {
         
         o.addTag("access", "private");
         assertTrue(o.isThroughTrafficExplicitlyDisallowed());
+
+        OSMWithTags way = new OSMWithTags();
+        way.addTag("motor_vehicle", "destination");
+        assertTrue(way.isThroughTrafficExplicitlyDisallowed());
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
+++ b/src/test/java/org/opentripplanner/openstreetmap/model/OSMWithTagsTest.java
@@ -110,20 +110,20 @@ public class OSMWithTagsTest {
     @Test
     public void testIsThroughTrafficExplicitlyDisallowed() {
         OSMWithTags o = new OSMWithTags();
-        assertFalse(o.isThroughTrafficExplicitlyDisallowed());
+        assertFalse(o.isMotorVehicleThroughTrafficExplicitlyDisallowed());
         
         o.addTag("access", "something");
-        assertFalse(o.isThroughTrafficExplicitlyDisallowed());
+        assertFalse(o.isMotorVehicleThroughTrafficExplicitlyDisallowed());
         
         o.addTag("access", "destination");
-        assertTrue(o.isThroughTrafficExplicitlyDisallowed());
+        assertTrue(o.isMotorVehicleThroughTrafficExplicitlyDisallowed());
         
         o.addTag("access", "private");
-        assertTrue(o.isThroughTrafficExplicitlyDisallowed());
+        assertTrue(o.isMotorVehicleThroughTrafficExplicitlyDisallowed());
 
         OSMWithTags way = new OSMWithTags();
         way.addTag("motor_vehicle", "destination");
-        assertTrue(way.isThroughTrafficExplicitlyDisallowed());
+        assertTrue(way.isMotorVehicleThroughTrafficExplicitlyDisallowed());
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/routing/core/BicycleAndWalkRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/BicycleAndWalkRoutingTest.java
@@ -211,4 +211,16 @@ public class BicycleAndWalkRoutingTest {
         var polyline2 = calculatePolyline(graph, bahnhof, guelsteinerStr, TraverseMode.BICYCLE);
         assertThatPolylinesAreEqual(polyline2, "c}qgHwbbu@@F~@o@FKBGBMCKMg@GWCOCEAIAIAK?M?OBMDMBIDIHGFEHCJELEd@MPEZKIs@Gq@_@{D`Cq@dBg@o@_HI{@GaACyAAqCiCK]UBC");
     }
+
+    @Test
+    public void shouldRespectNoThroughTraffic() {
+        var mozartStr = new GenericLocation(48.59521, 8.88391);
+        var fritzLeharStr = new GenericLocation(48.59460, 8.88291);
+
+        var polyline1 = calculatePolyline(getDefaultGraph(), mozartStr, fritzLeharStr);
+        assertThatPolylinesAreEqual(polyline1, "_grgHkcfu@OjBC\\ARGjAKzAfBz@j@n@Rk@E}D");
+
+        var polyline2 = calculatePolyline(getDefaultGraph(), fritzLeharStr, mozartStr);
+        assertThatPolylinesAreEqual(polyline2, "gcrgHc}eu@D|DSj@k@o@gB{@J{AFkA@SB]NkB");
+    }
 }

--- a/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
@@ -44,7 +44,7 @@ public class CarRoutingTest {
         GenericLocation seeStrasse = new GenericLocation(48.59724504108028,8.868606090545656);
         GenericLocation offTuebingerStr = new GenericLocation(48.58529481682537, 8.888196945190431);
 
-        var polyline = computePolyline(hindenburgStrUnderConstruction(), seeStrasse, offTuebingerStr);
+        var polyline = computePolyline(ordinaryHerrenbergGraph(), seeStrasse, offTuebingerStr);
 
         assertThatPolylinesAreEqual(polyline, "usrgHyccu@d@bAl@jAT\\JLFHNNLJJHJFLHNJLDPDT?NAN?FANCFAB?JADGDIFKDINULSHONa@FUJ_@Jo@DSBQJw@DkADi@D{@D_ATsDDu@Am@Ee@AUEi@Eu@C{@Bo@@IJYTi@HQT]T]\\e@|A}BZc@FKZg@P]vBgETa@j@cAr@uAv@}ANYVe@Xm@d@}@Ra@Vg@LWTa@`@y@`@w@b@w@Xi@Xg@Zi@RYR]Zg@f@u@X_@V_@r@aAp@y@f@s@h@o@b@k@V[V[X_@Xa@Va@V_@Ta@Ta@R_@Zm@Vk@j@qABGHUN_@Na@Xw@Vu@b@wANk@Pm@z@_DRu@");
     }
@@ -57,6 +57,16 @@ public class CarRoutingTest {
         var polyline = computePolyline(ordinaryHerrenbergGraph(), nagolderStr, horberstr);
 
         assertThatPolylinesAreEqual(polyline, "mirgHmkbu@Au@@m@?s@@cF@g@?k@@M@MBKBIHAF?D@FDB@HDFJHJLPHJJJj@n@PLLJHF");
+    }
+
+    @Test
+    public void shouldAvoidResidentialStreet() {
+        var nagolderStr = new GenericLocation(48.59571, 8.86581);
+        var zeppelinStr = new GenericLocation(48.59985,8.86537);
+
+        var polyline = computePolyline(hindenburgStrUnderConstruction(), nagolderStr, zeppelinStr);
+
+        assertThatPolylinesAreEqual(polyline, "}irgHgrbu@?bA?zB@XBnCInB]jFGrAGdAC|AU?eAFg@C}@Ks@CGAY?YD]Fm@X_@Pw@d@eAn@k@VM@]He@Fo@Bi@??c@?Q@gD?Q?Q@mD?y@?aD?eCAw@EiBKgB");
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
@@ -114,4 +114,16 @@ public class CarRoutingTest {
         var polyline5 = computePolyline(hindenburgStrUnderConstruction(), autobahn, aufDemGraben);
         assertThatPolylinesAreEqual(polyline5, "{pogHathu@G`@Gf@Gd@Kf@SjASfAWjAKf@I\\Sp@Ol@Ob@CJKZENQh@Ul@Qd@Sj@Yr@[t@u@dB]v@_@v@i@dA_@r@U`@Ub@U`@]p@Yn@Wl@O`@M\\Of@M\\Mf@Oj@[jA{@~CQl@Oj@c@vAWt@Yv@O`@O^ITCFk@pAWj@[l@S^U`@U`@W^W`@Y`@Y^WZWZc@j@i@n@g@r@q@x@s@`AW^Y^g@t@[f@S\\SX[h@Yf@Yh@c@v@a@v@a@x@U`@MVWf@S`@e@|@Yl@Wd@OXw@|As@tAk@bAU`@wBfEQ\\[f@GJ[b@}A|B]d@U\\U\\IPUh@KXAHCn@Bz@Dt@Dh@@TGBC@KBSHGx@");
     }
+
+    @Test
+    public void shouldRespectNoThroughTraffic() {
+        var mozartStr = new GenericLocation(48.59521, 8.88391);
+        var fritzLeharStr = new GenericLocation(48.59460, 8.88291);
+
+        var polyline1 = computePolyline(ordinaryHerrenbergGraph(), mozartStr, fritzLeharStr);
+        assertThatPolylinesAreEqual(polyline1, "_grgHkcfu@OjBC\\ARGjAKzAfBz@j@n@Rk@E}D");
+
+        var polyline2 = computePolyline(ordinaryHerrenbergGraph(), fritzLeharStr, mozartStr);
+        assertThatPolylinesAreEqual(polyline2, "gcrgHc}eu@D|DSj@k@o@gB{@J{AFkA@SB]NkB");
+    }
 }

--- a/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarRoutingTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.routing.core;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opentripplanner.ConstantsForTests;
 import org.opentripplanner.api.model.TripPlan;
@@ -18,13 +17,9 @@ import static org.opentripplanner.routing.core.PolylineAssert.assertThatPolyline
 
 public class CarRoutingTest {
 
-    static Graph ordinaryHerrenbergGraph = TestGraphBuilder.buildGraph(ConstantsForTests.HERRENBERG_OSM);
-    static Graph hindenburgStrUnderConstruction = TestGraphBuilder.buildGraph(ConstantsForTests.HERRENBERG_HINDENBURG_UNDER_CONSTRUCTION_OSM);
+    static Graph ordinaryHerrenbergGraph() { return TestGraphBuilder.buildGraph(ConstantsForTests.HERRENBERG_OSM); }
+    static Graph hindenburgStrUnderConstruction() { return TestGraphBuilder.buildGraph(ConstantsForTests.HERRENBERG_HINDENBURG_UNDER_CONSTRUCTION_OSM); };
     static long dateTime = TestUtils.dateInSeconds("Europe/Berlin", 2020, 03, 2, 7, 0, 0);
-
-    @BeforeClass
-    public static void setUp() {
-    }
 
     private static String computePolyline(Graph graph, GenericLocation from, GenericLocation to) {
         RoutingRequest request = new RoutingRequest();
@@ -49,7 +44,7 @@ public class CarRoutingTest {
         GenericLocation seeStrasse = new GenericLocation(48.59724504108028,8.868606090545656);
         GenericLocation offTuebingerStr = new GenericLocation(48.58529481682537, 8.888196945190431);
 
-        var polyline = computePolyline(ordinaryHerrenbergGraph, seeStrasse, offTuebingerStr);
+        var polyline = computePolyline(hindenburgStrUnderConstruction(), seeStrasse, offTuebingerStr);
 
         assertThatPolylinesAreEqual(polyline, "usrgHyccu@d@bAl@jAT\\JLFHNNLJJHJFLHNJLDPDT?NAN?FANCFAB?JADGDIFKDINULSHONa@FUJ_@Jo@DSBQJw@DkADi@D{@D_ATsDDu@Am@Ee@AUEi@Eu@C{@Bo@@IJYTi@HQT]T]\\e@|A}BZc@FKZg@P]vBgETa@j@cAr@uAv@}ANYVe@Xm@d@}@Ra@Vg@LWTa@`@y@`@w@b@w@Xi@Xg@Zi@RYR]Zg@f@u@X_@V_@r@aAp@y@f@s@h@o@b@k@V[V[X_@Xa@Va@V_@Ta@Ta@R_@Zm@Vk@j@qABGHUN_@Na@Xw@Vu@b@wANk@Pm@z@_DRu@");
     }
@@ -59,7 +54,7 @@ public class CarRoutingTest {
         var nagolderStr = new GenericLocation(48.59559, 8.86472);
         var horberstr = new GenericLocation(48.59459, 8.86647);
 
-        var polyline = computePolyline(ordinaryHerrenbergGraph, nagolderStr, horberstr);
+        var polyline = computePolyline(ordinaryHerrenbergGraph(), nagolderStr, horberstr);
 
         assertThatPolylinesAreEqual(polyline, "mirgHmkbu@Au@@m@?s@@cF@g@?k@@M@MBKBIHAF?D@FDB@HDFJHJLPHJJJj@n@PLLJHF");
     }
@@ -69,7 +64,7 @@ public class CarRoutingTest {
         var gueltsteinerStr = new GenericLocation(48.59240, 8.87024);
         var aufDemGraben = new GenericLocation(48.59487, 8.87133);
 
-        var polyline = computePolyline(hindenburgStrUnderConstruction, gueltsteinerStr, aufDemGraben);
+        var polyline = computePolyline(hindenburgStrUnderConstruction(), gueltsteinerStr, aufDemGraben);
 
         assertThatPolylinesAreEqual(polyline, "ouqgH}mcu@gAE]U}BaA]Q}@]uAs@[SAm@Ee@AUEi@XEQkBQ?Bz@Dt@Dh@@TGBC@KBSHGx@");
     }
@@ -79,10 +74,10 @@ public class CarRoutingTest {
         var nagolderStr = new GenericLocation(48.59559, 8.86472);
         var aufDemGraben = new GenericLocation(48.59487, 8.87133);
 
-        var polyline1 = computePolyline(hindenburgStrUnderConstruction, nagolderStr, aufDemGraben);
+        var polyline1 = computePolyline(hindenburgStrUnderConstruction(), nagolderStr, aufDemGraben);
         assertThatPolylinesAreEqual(polyline1, "mirgHmkbu@Au@@m@?s@@cF@g@?k@@M@MBKBIHAF?D@FDB@HDFJHJLPHJJJj@n@PLLJNLPNp@p@NNNPJNDHFLHTTdA^zADNDLFH@BBDJLDBDBDBH@B@F?X@X@p@BfB@v@?lA@D?xA@b@?Z@h@?d@?[}D[cD[uD]qDYcDEWg@{FkAEmAIKAiCK]U}BaA]Q}@]uAs@[SAm@Ee@AUEi@XEQkBQ?Bz@Dt@Dh@@TGBC@KBSHGx@");
 
-        var polyline2 = computePolyline(hindenburgStrUnderConstruction, aufDemGraben, nagolderStr);
+        var polyline2 = computePolyline(hindenburgStrUnderConstruction(), aufDemGraben, nagolderStr);
         assertThatPolylinesAreEqual(polyline2, "}drgHytcu@Fy@RIJCBAFCDd@@l@ZRtAr@|@\\\\P|B`A\\T?dDHn@l@hE?BZlCVjCV`CFv@BZBXHr@@PBTBP@N?N?J@L?bAw@?gBAq@CYAYAG?CAIAECECECKMCEACGIEMEO_@{AUeAIUGMEIKOOQOOq@q@QOOMMKQMk@o@KKIKMQIKGKKMIGCEGCGAA?EAG@EJA@CHALAJ?R?T?VA^?h@A`E?zB@XBnCInB]jFGrAGdAC|APIBuABaAb@uGBe@D_A?_AAaB?c@");
     }
 
@@ -94,19 +89,19 @@ public class CarRoutingTest {
         var seestr = new GenericLocation(48.60158, 8.87313);
         var aufDemGraben = new GenericLocation(48.59487, 8.87133);
 
-        var polyline1 = computePolyline(hindenburgStrUnderConstruction, nagolderStr, autobahn);
+        var polyline1 = computePolyline(hindenburgStrUnderConstruction(), nagolderStr, autobahn);
         assertThatPolylinesAreEqual(polyline1, "mirgHmkbu@Au@@m@?s@@cF@g@?k@@M@MBKBIHAF?D@FDB@HDFJHJLPHJJJj@n@PLLJNLPNp@p@NNNPJNDHFLHTTdA^zADNDLFH@BBDJLDBDBDBH@B@F?X@X@p@BfB@v@?lA@D?xA@b@?Z@h@?d@?XCTCVCXA`AKdAKbCStBSxAKv@Ez@Ax@Dd@Nx@^dAdAr@nAR`@h@rAl@xBRl@HXf@n@b@Vj@PjAHj@@N?bA@`@?`@EXG`@OjAi@t@UhAYnBa@lB_@tBSZCtGk@xAO|BUrCUl@?h@Bh@FrAPNFPFLDHDF@DB@FBF@BBDBBB@F@F?DCDCBEBEBI@G?K?GAICGCG@W@UB]BWBMDYFYHg@FUDSFUDSFQFOHUHSHWRe@`@_APe@Rg@Pa@Nc@Rm@Tm@Ro@Rm@Ro@Pq@Rq@Pq@^wA^uA^wA^uALi@J]Pq@Rs@h@gBNg@Ne@Pe@Tm@Xy@Zw@\\y@Zu@\\s@NYPa@Ta@Ra@NWXg@Zi@Zg@Xg@LQn@cAVa@T_@d@q@f@s@PYRYPYR[NYNYLWN_@N[HWJ[J]La@H]F]Ha@D[D[BWD_@Da@B_@@]B]@[?W@W?Y?Y?o@A[?WA_@Ca@C]Gi@Go@Ie@Ki@Ie@Mm@G]G]G]G]E]Ee@CYC]Cc@A]Aa@A]?]?a@?a@@]@a@@_@F}@Fw@Bi@Ba@Be@@W?[@c@?e@AY?_@A_@C_@C_@Ca@C[E_@Ga@G]E[I]G[K_@IYIYK[M[M[MYMWQ]S[QWOSOSOOOOOMOOOMMSSWEIAGAGAECECECCCAEAC?E?E@CBCDSCQAYEQIQIg@Sc@Sa@Qi@Si@Sg@QUKg@Oi@Qi@Og@Qe@Mc@KQEUGQEQEe@Ke@KWEUESCKAIAUAO?KAK?K@O?K@U@OBSD{A\\eAT_Dz@gC~@aA^_@LI@I@I@IBI?E?CECCCCCAE?E?EBCBEDADCF?FKDEBOHIDIHQDQBOBOBUBM@Q@Q@MAOAI?SEWESEeAWi@OWI_@MICME[Ks@WmAe@OGSIOIOISKOKMKKIWYQ_@EKCE?EAI?KBa@Nc@Nm@Rq@H]Jg@VkARgARkAJg@Fe@Fg@Fa@");
 
-        var polyline2 = computePolyline(hindenburgStrUnderConstruction, autobahn, nagolderStr);
+        var polyline2 = computePolyline(hindenburgStrUnderConstruction(), autobahn, nagolderStr);
         assertThatPolylinesAreEqual(polyline2, "{pogHathu@G`@Gf@Gd@Kf@SjASfAWjAKf@I\\Sp@Ol@Ob@CJKZEN?HBNBJDDPNB@b@RJHLJNJRJNHNHRHNFlAd@r@VZJLDHB^LVHh@NdAVRDVDRDH?N@L@PAPALATCNCNCPCPEH?J?NCF?B?H?@DDDBBD@D?DABCDCBE@G@E@GFGDCFCHGHEFK^M`A_@fC_A~C{@dAUzA]RENCTAJAN?JAJ?J@N?T@H@J@RBTDVDd@Jd@JPDPDTFPDb@Jd@Lf@Ph@Nh@Pf@NTJf@Ph@Rh@R`@Pb@Rf@RPHPHXXHFHHDD@F?FBD@DBDDDBBD@D?FADCDEN@N@PFNLNNNLNNNNNRNRPVRZP\\LVLXLZLZJZHXHXJ^FZH\\DZF\\F`@D^BZB`@B^B^@^?^@X?d@Ab@?ZAVCd@C`@Ch@Gv@G|@A^A`@A\\?`@?`@?\\@\\@`@@\\Bb@B\\BXDd@D\\F\\F\\F\\F\\Ll@Hd@Jh@Hd@Fn@Fh@B\\B`@@^?V@Z?n@?X?XAV?VAZC\\A\\C^E`@E^CVEZEZI`@G\\I\\M`@K\\KZIVOZO^MVOXOXSZQXSXQXg@r@e@p@U^W`@o@bAMPYf@[f@[h@Yf@OVS`@U`@Q`@OX]r@[t@]x@[v@Yx@Ul@Qd@Od@Of@i@fBSr@Qp@K\\Mh@_@tA_@vA_@tA_@vAQp@Sp@Qp@Sn@Sl@Sn@Ul@Sl@Ob@Q`@Sf@Qd@a@~@Sd@IVIRITGNGPERGTERGTIf@GXEXCLGRGPIVEPCHE?EBCBEFADK@C?O@U?U?sAQi@Gi@Cm@?sCT}BTyANuGj@[BuBRmB^oB`@iAXu@TkAh@a@NYFa@Da@?cAAO?k@AkAIk@Qc@Wg@o@IYSm@m@yBi@sASa@s@oAeAeAy@_@e@Oy@E{@@w@DyAJuBRcCReAJaAJY@WBUBYBe@?i@?[Ac@?yAAE?mAAw@?gBAq@CYAYAG?CAIAECECECKMCEACGIEMEO_@{AUeAIUGMEIKOOQOOq@q@QOOMMKQMk@o@KKIKMQIKGKKMIGCEGCGAA?EAG@EJA@CHALAJ?R?T?VA^?h@A`E?zB@XBnCInB]jFGrAGdAC|APIBuABaAb@uGBe@D_A?_AAaB?c@");
 
-        var polyline3 = computePolyline(hindenburgStrUnderConstruction, autobahn, seestr);
+        var polyline3 = computePolyline(hindenburgStrUnderConstruction(), autobahn, seestr);
         assertThatPolylinesAreEqual(polyline3, "{pogHathu@G`@Gf@Gd@Kf@SjASfAWjAKf@I\\Sp@Ol@Ob@CJKZEN?HBNBJDDPNB@b@RJHLJNJRJNHNHRHNFlAd@r@VZJLDHB^LVHh@NdAVRDVDRDH?N@L@PAPALATCNCNCPCPEH?J?NCF?B?H?@DDDBBD@D?DABCDCBE@G@E@GFGDCFCHGHEFK^M`A_@fC_A~C{@dAUzA]RENCTAJAN?JAJ?J@N?T@H@J@RBTDVDd@Jd@JPDPDTFPDb@Jd@Lf@Ph@Nh@Pf@NTJf@Ph@Rh@R`@Pb@Rf@RPHPHXXHFHHDD@F?FBD@DBDDDBBD@D?FADCDEN@N@PFNLNNNLNNNNNRNRPVRZP\\LVLXLZLZJZHXHXJ^FZH\\DZF\\F`@D^BZB`@B^B^@^?^@X?d@Ab@?ZAVCd@C`@Ch@Gv@G|@A^A`@A\\?`@?`@?\\@\\@`@@\\Bb@B\\BXDd@D\\F\\F\\F\\F\\Ll@Hd@Jh@Hd@Fn@Fh@B\\B`@@^?V@Z?n@?X?XAV?VAZC\\A\\C^E`@E^CVEZEZI`@G\\I\\M`@K\\KZIVOZO^MVOXOXSZQXSXQXg@r@e@p@U^W`@o@bAMPYf@[f@[h@Yf@OVS`@U`@Q`@OX]r@[t@]x@[v@Yx@Ul@Qd@Od@Of@i@fBSr@Qp@K\\Mh@_@tA_@vA_@tA_@vAQp@Sp@Qp@Sn@Sl@Sn@Ul@Sl@Ob@Q`@Sf@Qd@a@~@Sd@IVIRITGNGPERGTERGTIf@GXEXCLGRGPIVEPCHE?EBCBEFADK@C?O@U?U?sAQi@Gi@Cm@?sCT}BTyANuGj@[BuBRmB^oB`@iAXu@TkAh@a@NYFa@Da@?cAAO?k@AkAIk@Qc@Wg@o@IYSm@m@yBi@sASa@s@oAeAeAy@_@e@Oy@E{@@w@DyAJuBRcCReAJaAJY@WBUBYBe@?i@?[Ac@?yAAE?mAAw@?gBAq@CYAYAG?CAIAECECECKMCEACGIEMEO_@{AUeAIUGMEIKOOQOOq@q@QOOMMKQMk@o@KKIKMQIKGKKMIGCEGCGAA?EAG@WBI@I@MBO@UAKAKAQCMEKGKIMKOOGIKMNi@HSNa@Py@e@]k@{@Sa@]C]d@GF]q@y@_B?[KYIUU\\KPOWEGYe@[i@i@{@Wc@OWCAQYKQEGkA}AQUSS}@s@iA{@_Bw@uAg@WKo@SMECA");
 
-        var polyline4 = computePolyline(hindenburgStrUnderConstruction, autobahn, affstädt);
+        var polyline4 = computePolyline(hindenburgStrUnderConstruction(), autobahn, affstädt);
         assertThatPolylinesAreEqual(polyline4, "{pogHathu@G`@Gf@Gd@Kf@SjASfAWjAKf@I\\Sp@Ol@Ob@CJKZEN?HBNBJDDPNB@b@RJHLJNJRJNHNHRHNFlAd@r@VZJLDHB^LVHh@NdAVRDVDRDH?N@L@PAPALATCNCNCPCPEH?J?NCF?B?H?@DDDBBD@D?DABCDCBE@G@E@GFGDCFCHGHEFK^M`A_@fC_A~C{@dAUzA]RENCTAJAN?JAJ?J@N?T@H@J@RBTDVDd@Jd@JPDPDTFPDb@Jd@Lf@Ph@Nh@Pf@NTJf@Ph@Rh@R`@Pb@Rf@RPHPHXXHFHHDD@F?FBD@DBDDDBBD@D?FADCDEN@N@PFNLNNNLNNNNNRNRPVRZP\\LVLXLZLZJZHXHXJ^FZH\\DZF\\F`@D^BZB`@B^B^@^?^@X?d@Ab@?ZAVCd@C`@Ch@Gv@G|@A^A`@A\\?`@?`@?\\@\\@`@@\\Bb@B\\BXDd@D\\F\\F\\F\\F\\Ll@Hd@Jh@Hd@Fn@Fh@B\\B`@@^?V@Z?n@?X?XAV?VAZC\\A\\C^E`@E^CVEZEZI`@G\\I\\M`@K\\KZIVOZO^MVOXOXSZQXSXQXg@r@e@p@U^W`@o@bAMPYf@[f@[h@Yf@OVS`@U`@Q`@OX]r@[t@]x@[v@Yx@Ul@Qd@Od@Of@i@fBSr@Qp@K\\Mh@_@tA_@vA_@tA_@vAQp@Sp@Qp@Sn@Sl@Sn@Ul@Sl@Ob@Q`@Sf@Qd@a@~@Sd@IVIRITGNGPERGTERGTIf@GXEXCLGRGPIVEPCHE?EBCBEFADK@C?O@U?U?sAQi@Gi@Cm@?sCT}BTyANuGj@[BuBRmB^oB`@iAXu@TkAh@a@NYFa@Da@?cAAO?k@AkAIk@Qc@Wg@o@IYSm@m@yBi@sASa@s@oAeAeAy@_@e@Oy@E{@@w@DyAJuBRcCReAJaAJY@WBUBYBe@?i@?[Ac@?yAAE?mAAw@?gBAq@CYAYAG?CAIAECECECKMCEACGIEMEO_@{AUeAIUGMEIKOOQOOq@q@QOOMMKQMk@o@KKIKMQIKGKKMIGCEGCGAA?EAG@EJA@CHALAJ?R?T?VA^?h@A`E?zB@XBnCInB]jFGrAGdAC|AU?eAFg@C}@Ks@CGAY?YD]Fm@X_@Pw@d@eAn@k@VM@]He@Fo@Bi@?[E{Di@_@GwBMqC@oCRsCZeDj@a@J_AN{@Pp@vGaBhAgB`@cAXSN");
 
-        var polyline5 = computePolyline(hindenburgStrUnderConstruction, autobahn, aufDemGraben);
+        var polyline5 = computePolyline(hindenburgStrUnderConstruction(), autobahn, aufDemGraben);
         assertThatPolylinesAreEqual(polyline5, "{pogHathu@G`@Gf@Gd@Kf@SjASfAWjAKf@I\\Sp@Ol@Ob@CJKZENQh@Ul@Qd@Sj@Yr@[t@u@dB]v@_@v@i@dA_@r@U`@Ub@U`@]p@Yn@Wl@O`@M\\Of@M\\Mf@Oj@[jA{@~CQl@Oj@c@vAWt@Yv@O`@O^ITCFk@pAWj@[l@S^U`@U`@W^W`@Y`@Y^WZWZc@j@i@n@g@r@q@x@s@`AW^Y^g@t@[f@S\\SX[h@Yf@Yh@c@v@a@v@a@x@U`@MVWf@S`@e@|@Yl@Wd@OXw@|As@tAk@bAU`@wBfEQ\\[f@GJ[b@}A|B]d@U\\U\\IPUh@KXAHCn@Bz@Dt@Dh@@TGBC@KBSHGx@");
     }
 }


### PR DESCRIPTION
This PR introduces the separation of the no-through-traffic rule for motor vehicles and bicycles.

All the tests pass and there was even a bicycle test case already in the test suit: the route from Nebringen to Herrenberg would go via this way https://www.openstreetmap.org/way/89457356 if we simply disabled no-through-traffic for bicycles. With a separate mode, however, we get this route: https://tinyurl.com/ycuchalq

I've also added test cases the check that it really is respected for bicycles and motor vehicles.
