### PR TITLE
ParkAPI integration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -665,6 +665,14 @@ connect to a network resource is the `url` field.
         // Streaming differential GTFS-RT TripUpdates over websockets
         {
             "type": "websocket-gtfs-rt-updater"
+        },
+        // Polling for car park information including the number of available spaces
+        {
+            "id": "park-api",
+            "type": "car-park",
+            "frequencySec": 120,
+            "sourceType": "park-api",
+            "url": "https://api.stadtnavi.de/parkapi.json"
         }
     ]
 }

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -724,9 +724,8 @@ public abstract class RoutingResource {
         if (maxTransfers != null)
             request.maxTransfers = maxTransfers;
 
-        final long NOW_THRESHOLD_MILLIS = 15 * 60 * 60 * 1000;
-        boolean tripPlannedForNow = Math.abs(request.getDateTime().getTime() - new Date().getTime()) < NOW_THRESHOLD_MILLIS;
-        request.useBikeRentalAvailabilityInformation = (tripPlannedForNow); // TODO the same thing for GTFS-RT
+
+        request.useBikeRentalAvailabilityInformation = request.isTripPlannedForNow(); // TODO the same thing for GTFS-RT
 
         if (startTransitStopId != null && !startTransitStopId.isEmpty())
             request.startingTransitStopId = FeedScopedId.convertFromString(startTransitStopId);

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -599,17 +599,17 @@ public abstract class GraphPathToTripPlanConverter {
             }
         }
 
-        addCarParkAlerts(leg, states);
+        addCarParkAlerts(leg, states, requestedLocale);
     }
 
-    private static void addCarParkAlerts(Leg leg, State[] state) {
+    private static void addCarParkAlerts(Leg leg, State[] state, Locale locale) {
         var isTripPlannedForNow = Arrays.stream(state)
                 .findFirst()
                 .map(s -> s.getOptions().isTripPlannedForNow())
                 .orElse(false);
 
         if(isTripPlannedForNow && containsCarParkWithFewSpaces(state)){
-            leg.addAlert(Alert.createLowCarParkSpacesAlert(), Locale.ENGLISH);
+            leg.addAlert(Alert.createLowCarParkSpacesAlert(), locale);
         }
     }
 

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -356,6 +356,7 @@ public abstract class GraphPathToTripPlanConverter {
         leg.rentedBike = states[0].isBikeRenting() && states[states.length - 1].isBikeRenting();
 
         addModeAndAlerts(graph, leg, states, disableAlertFiltering, requestedLocale);
+
         if (leg.isTransitLeg()) addRealTimeData(leg, states);
 
         return leg;

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A library class with only static methods used in converting internal GraphPaths to TripPlans, which are
@@ -598,6 +599,19 @@ public abstract class GraphPathToTripPlanConverter {
                     }
                 }
             }
+        }
+
+        addCarParkAlerts(leg, states);
+    }
+
+    private static void addCarParkAlerts(Leg leg, State[] state) {
+        var containsCarParkWithFewSpaces = Arrays.stream(state)
+                .filter(s -> s.getVertex() instanceof ParkAndRideVertex)
+                .map(s -> (ParkAndRideVertex) s.getVertex())
+                .anyMatch(ParkAndRideVertex::hasFewSpacesAvailable);
+
+        if(containsCarParkWithFewSpaces){
+            leg.addAlert(Alert.createLowCarParkSpacesAlert(), Locale.ENGLISH);
         }
     }
 

--- a/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
+++ b/src/main/java/org/opentripplanner/index/GraphQlPlanner.java
@@ -286,6 +286,8 @@ public class GraphQlPlanner {
         boolean tripPlannedForNow = Math.abs(request.getDateTime().getTime() - new Date().getTime()) < NOW_THRESHOLD_MILLIS;
         request.useBikeRentalAvailabilityInformation = (tripPlannedForNow); // TODO the same thing for GTFS-RT
 
+        callWith.argument("useCarParkAvailabilityInformation", (Boolean v) -> request.useBikeRentalAvailabilityInformation = v);
+
         callWith.argument("startTransitStopId", (String v) -> request.startingTransitStopId = GtfsLibrary.convertIdFromString(v));
         callWith.argument("startTransitTripId", (String v) -> request.startingTransitTripId = GtfsLibrary.convertIdFromString(v));
         callWith.argument("clamInitialWait", (Long v) -> request.clampInitialWait = v);

--- a/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
+++ b/src/main/java/org/opentripplanner/index/IndexGraphQLSchema.java
@@ -2556,6 +2556,18 @@ public class IndexGraphQLSchema {
                         .type(Scalars.GraphQLFloat)
                         .dataFetcher(environment -> ((CarPark) environment.getSource()).y)
                         .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("url")
+                        .description("URL of additional information of this car park.")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(environment -> ((CarPark) environment.getSource()).url)
+                        .build())
+                .field(GraphQLFieldDefinition.newFieldDefinition()
+                        .name("openingHours")
+                        .description("Opening hours in OSM format (https://wiki.openstreetmap.org/wiki/Key:opening_hours).")
+                        .type(Scalars.GraphQLString)
+                        .dataFetcher(environment -> ((CarPark) environment.getSource()).openingHours)
+                        .build())
                 .build();
 
         GraphQLInputObjectType filterInputType = GraphQLInputObjectType.newInputObject()

--- a/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.routing.alertpatch;
 
 import com.google.transit.realtime.GtfsRealtime;
+import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
 
@@ -41,6 +42,13 @@ public class Alert implements Serializable {
         Alert note = new Alert();
         note.alertHeaderText = new NonLocalizedString(text);
         return note;
+    }
+
+    public static Alert createLowCarParkSpacesAlert() {
+        var alert = createSimpleAlerts("Car park with few spaces available selected.");
+        alert.alertDescriptionText = new NonLocalizedString("A car park on your journey has few parking spaces available. Please expect additional waiting time on your trip.");
+        alert.alertUrl = new NonLocalizedString("alert:carpark:few-spaces-available");
+        return alert;
     }
 
     public boolean equals(Object o) {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
@@ -3,11 +3,13 @@ package org.opentripplanner.routing.alertpatch;
 import com.google.transit.realtime.GtfsRealtime;
 import org.opentripplanner.api.model.alertpatch.LocalizedAlert;
 import org.opentripplanner.util.I18NString;
+import org.opentripplanner.util.LocalizedString;
 import org.opentripplanner.util.NonLocalizedString;
 
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 
 public class Alert implements Serializable {
@@ -45,9 +47,10 @@ public class Alert implements Serializable {
     }
 
     public static Alert createLowCarParkSpacesAlert() {
-        var alert = createSimpleAlerts("Car park with few spaces available selected.");
-        alert.alertDescriptionText = new NonLocalizedString("A car park on your journey has few parking spaces available. Please expect additional waiting time on your trip.");
-        alert.alertUrl = new NonLocalizedString("alert:carpark:few-spaces-available");
+        var emptyArray = new String[]{};
+        var alert = new Alert();
+        alert.alertHeaderText= new LocalizedString("alert.car_park.full.header", emptyArray);
+        alert.alertDescriptionText = new LocalizedString("alert.car_park.full.description", emptyArray);
         return alert;
     }
 

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -50,6 +50,14 @@ public class CarPark implements Serializable {
     @JsonSerialize
     public int maxCapacity = Integer.MAX_VALUE;
 
+    @XmlAttribute
+    @JsonSerialize
+    public String openingHours;
+
+    @XmlAttribute
+    @JsonSerialize
+    public String url;
+
     /**
      * Whether this parking has space available information updated in real-time. If no real-time
      * data, users should take spacesAvailable with a pinch of salt, as they are a crude estimate.

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -85,7 +85,20 @@ public class CarPark implements Serializable {
     }
 
     public boolean hasFewSpacesAvailable() {
-        var percentFree = ((float) spacesAvailable / maxCapacity);
-        return !(Double.isNaN(percentFree)) && percentFree < 0.1;
+        return hasFewSpacesAvailable(spacesAvailable, maxCapacity);
+    }
+
+    public static boolean hasFewSpacesAvailable(int spacesAvailable, int maxCapacity) {
+        // special handling if it is a very small car park
+        if(maxCapacity < 10) {
+            return spacesAvailable <= 1;
+        // special handling if it is a large one: 20 parking spaces is enough
+        } else if(maxCapacity > 200){
+            return spacesAvailable < 20;
+        // for everything in the middle the cutoff is 10 percent
+        } else {
+            var percentFree = ((float) spacesAvailable / maxCapacity);
+            return !(Double.isNaN(percentFree)) && percentFree <= 0.1f;
+        }
     }
 }

--- a/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
+++ b/src/main/java/org/opentripplanner/routing/car_park/CarPark.java
@@ -83,4 +83,9 @@ public class CarPark implements Serializable {
     public String toString () {
         return String.format(Locale.US, "Car park %s at %.6f, %.6f", name, y, x);
     }
+
+    public boolean hasFewSpacesAvailable() {
+        var percentFree = ((float) spacesAvailable / maxCapacity);
+        return !(Double.isNaN(percentFree)) && percentFree < 0.1;
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1672,4 +1672,8 @@ public class RoutingRequest implements Cloneable, Serializable {
         return allowedFares == null ? "All zones allowed" : "Allowed zones: " + allowedFares.toString();
     }
 
+    public boolean isTripPlannedForNow() {
+        final long NOW_THRESHOLD_MILLIS = 15 * 60 * 60 * 1000;
+        return Math.abs(getDateTime().getTime() - new Date().getTime()) < NOW_THRESHOLD_MILLIS;
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -358,6 +357,16 @@ public class RoutingRequest implements Cloneable, Serializable {
      * Whether or not bike rental availability information will be used to plan bike rental trips
      */
     public boolean useBikeRentalAvailabilityInformation = false;
+
+    /**
+     * By default only an alert is added when a car park on a route is close to being full.
+     *
+     * However, if you want to exclude those car parks, then set this parameter to true.
+     *
+     * Please note that these parameters only work when searching for the current time. When searching in the future
+     * they have no effect as the availability is not considered at all.
+     */
+    public boolean useCarParkAvailabilityInformation = false;
 
     /**
      * The maximum wait time in seconds the user is willing to delay trip start. Only effective in Analyst.
@@ -1248,7 +1257,8 @@ public class RoutingRequest implements Cloneable, Serializable {
                 && flexIgnoreDrtAdvanceBookMin == other.flexIgnoreDrtAdvanceBookMin
                 && flexMinPartialHopLength == other.flexMinPartialHopLength
                 && clockTimeSec == other.clockTimeSec
-                && serviceDayLookout == other.serviceDayLookout;
+                && serviceDayLookout == other.serviceDayLookout
+                && useCarParkAvailabilityInformation == other.useCarParkAvailabilityInformation;
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -36,6 +36,11 @@ public class ParkAndRideEdge extends Edge {
         if (!request.parkAndRide) {
             return null;
         }
+        if(request.useCarParkAvailabilityInformation
+                && request.isTripPlannedForNow()
+                && ((ParkAndRideVertex) tov).hasFewSpacesAvailable()){
+            return null;
+        }
         if (request.arriveBy) {
             /*
              * To get back a car, we need to walk and have car mode enabled.
@@ -62,11 +67,6 @@ public class ParkAndRideEdge extends Edge {
             }
             if (s0.isCarParked()) {
                 throw new IllegalStateException("Can't drive 2 cars");
-            }
-            if(request.useCarParkAvailabilityInformation
-                    && request.isTripPlannedForNow()
-                    && ((ParkAndRideVertex) tov).hasFewSpacesAvailable()){
-                return null;
             }
             StateEditor s1 = s0.edit(this);
                  

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -63,6 +63,11 @@ public class ParkAndRideEdge extends Edge {
             if (s0.isCarParked()) {
                 throw new IllegalStateException("Can't drive 2 cars");
             }
+            if(request.useCarParkAvailabilityInformation
+                    && request.isTripPlannedForNow()
+                    && ((ParkAndRideVertex) tov).hasFewSpacesAvailable()){
+                return null;
+            }
             StateEditor s1 = s0.edit(this);
                  
             int time = request.carDropoffTime;

--- a/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ParkAndRideEdge.java
@@ -36,9 +36,6 @@ public class ParkAndRideEdge extends Edge {
         if (!request.parkAndRide) {
             return null;
         }
-        if (((ParkAndRideVertex) tov).spacesAvailable == 0) {
-            return null;
-        }
         if (request.arriveBy) {
             /*
              * To get back a car, we need to walk and have car mode enabled.

--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.spt;
 
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.edgetype.SimpleTransfer;
 import org.opentripplanner.routing.edgetype.StreetEdge;
 import org.opentripplanner.routing.edgetype.TimedTransferEdge;
@@ -111,7 +112,9 @@ public abstract class DominanceFunction implements Serializable {
                 /**
                  * {@link DominanceFunction.MAX_METERS_ROUTE_LOOPS}
                  */
-                || isCloseToStartOrEnd(a.getVertex(), a.getOptions())) {
+                // when A* loops are allowed for bike rental searches then OTP runs into timeouts in areas with lots of cycling stations
+                // it's not quite clear why that is
+                || !(a.getOptions().allowBikeRental && a.getBackMode() == TraverseMode.WALK) && isCloseToStartOrEnd(a.getVertex(), a.getOptions())) {
                 return false;
             }
         }

--- a/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
@@ -34,6 +34,7 @@ public class ParkAndRideVertex extends Vertex {
         super(graph, carPark.id, carPark.x, carPark.y, carPark.name);
         this.carPark = carPark;
         this.spacesAvailable = carPark.spacesAvailable;
+        this.capacity = carPark.maxCapacity;
         setId(carPark.id);
     }
 
@@ -51,6 +52,6 @@ public class ParkAndRideVertex extends Vertex {
 
     public boolean hasFewSpacesAvailable() {
         var percentFree = ((float) spacesAvailable / capacity);
-        return percentFree < 0.1;
+        return !(Double.isNaN(percentFree)) && percentFree < 0.1;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
@@ -20,9 +20,6 @@ public class ParkAndRideVertex extends Vertex {
 
     private String id;
 
-    public int spacesAvailable = Integer.MAX_VALUE;
-    public int capacity = Integer.MAX_VALUE;
-
     private CarPark carPark;
 
     public ParkAndRideVertex(Graph g, String label, String id, double x, double y, I18NString name) {
@@ -33,8 +30,6 @@ public class ParkAndRideVertex extends Vertex {
     public ParkAndRideVertex(Graph graph, CarPark carPark) {
         super(graph, carPark.id, carPark.x, carPark.y, carPark.name);
         this.carPark = carPark;
-        this.spacesAvailable = carPark.spacesAvailable;
-        this.capacity = carPark.maxCapacity;
         setId(carPark.id);
     }
 
@@ -50,8 +45,12 @@ public class ParkAndRideVertex extends Vertex {
         return carPark;
     }
 
+    public void updateCapacity(int maxCapacity, int spacesAvailable) {
+        carPark.maxCapacity = maxCapacity;
+        carPark.spacesAvailable = spacesAvailable;
+    }
+
     public boolean hasFewSpacesAvailable() {
-        var percentFree = ((float) spacesAvailable / capacity);
-        return !(Double.isNaN(percentFree)) && percentFree < 0.1;
+        return carPark.hasFewSpacesAvailable();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/ParkAndRideVertex.java
@@ -21,6 +21,7 @@ public class ParkAndRideVertex extends Vertex {
     private String id;
 
     public int spacesAvailable = Integer.MAX_VALUE;
+    public int capacity = Integer.MAX_VALUE;
 
     private CarPark carPark;
 
@@ -46,5 +47,10 @@ public class ParkAndRideVertex extends Vertex {
 
     public CarPark getCarPark() {
         return carPark;
+    }
+
+    public boolean hasFewSpacesAvailable() {
+        var percentFree = ((float) spacesAvailable / capacity);
+        return percentFree < 0.1;
     }
 }

--- a/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
@@ -176,6 +176,7 @@ public class CarParkUpdater extends PollingGraphUpdater {
                     verticesByPark.put(carPark, carParkVertex);
                 } else {
                     verticesByPark.get(carPark).spacesAvailable = carPark.spacesAvailable;
+                    verticesByPark.get(carPark).capacity = carPark.maxCapacity;
                 }
             }
             /* Remove existing parks that were not present in the update */

--- a/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
@@ -175,8 +175,7 @@ public class CarParkUpdater extends PollingGraphUpdater {
                     }
                     verticesByPark.put(carPark, carParkVertex);
                 } else {
-                    verticesByPark.get(carPark).spacesAvailable = carPark.spacesAvailable;
-                    verticesByPark.get(carPark).capacity = carPark.maxCapacity;
+                    verticesByPark.get(carPark).updateCapacity(carPark.maxCapacity, carPark.spacesAvailable);
                 }
             }
             /* Remove existing parks that were not present in the update */

--- a/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/CarParkUpdater.java
@@ -72,8 +72,7 @@ public class CarParkUpdater extends PollingGraphUpdater {
 
     private SimpleStreetSplitter linker;
 
-    public CarParkUpdater() {
-    }
+    public CarParkUpdater() { }
 
     @Override
     public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
@@ -88,6 +87,9 @@ public class CarParkUpdater extends PollingGraphUpdater {
         if (sourceType != null) {
             if (sourceType.equals("hsl-parkandride")) {
                 source = new HslCarParkDataSource();
+            }
+            else if (sourceType.equals("park-api")) {
+                source = new ParkApiDataSource();
             }
         }
 
@@ -195,5 +197,12 @@ public class CarParkUpdater extends PollingGraphUpdater {
                 verticesByPark.remove(carPark);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "CarParkUpdater{" +
+                "source=" + source +
+                '}';
     }
 }

--- a/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
@@ -1,0 +1,71 @@
+package org.opentripplanner.updater.car_park;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.geotools.xml.xsi.XSISimpleTypes;
+import org.locationtech.jts.geom.*;
+import org.opentripplanner.routing.car_park.CarPark;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.util.NonLocalizedString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load car parks from a ParkAPI (https://github.com/offenesdresden/ParkAPI) JSON file.
+ */
+public class ParkApiDataSource extends GenericJsonCarParkDataSource{
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParkApiDataSource.class);
+
+    private String url;
+    private GeometryFactory gf = new GeometryFactory();
+
+    public ParkApiDataSource() {
+        super("lots");
+    }
+
+    @Override
+    public CarPark makeCarPark(JsonNode node) {
+
+        var carPark = new CarPark();
+        carPark.name = new NonLocalizedString(node.path("name").asText());
+        carPark.id = node.path("id").asText();
+
+        var coords = node.path("coords");
+        carPark.x = coords.path("lng").asDouble();
+        carPark.y = coords.path("lat").asDouble();
+
+        carPark.spacesAvailable = node.path("/free").asInt(Integer.MAX_VALUE);
+        carPark.maxCapacity = node.path("/total").asInt(Integer.MAX_VALUE);
+        carPark.realTimeData = true;
+
+        carPark.geometry = gf.createPoint(new Coordinate(carPark.x, carPark.y));
+
+        carPark.openingHours = node.path("opening_hours").asText();
+        carPark.url = node.path("url").asText(null);
+
+        return carPark;
+    }
+
+    /**
+     * Note that the JSON being passed in here is for configuration of the OTP component, it's completely separate
+     * from the JSON coming in from the update source.
+     */
+    @Override
+    public void configure (Graph graph, JsonNode jsonNode) {
+        super.configure(graph, jsonNode);
+        String url = jsonNode.path("url").asText(); // path() returns MissingNode not null.
+        if (url != null && !url.isEmpty()) {
+            this.url = url;
+        } else {
+            LOG.error("Could read URL for retrieving ParkAPI data.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ParkApiDataSource{" +
+                "url='" + url + '\'' +
+                '}';
+    }
+}
+

--- a/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
@@ -27,7 +27,11 @@ public class ParkApiDataSource extends GenericJsonCarParkDataSource{
     public CarPark makeCarPark(JsonNode node) {
 
         var carPark = new CarPark();
-        carPark.name = new NonLocalizedString(node.path("name").asText());
+
+        var lot_type = node.path("lot_type").asText("");
+        var name = node.path("name").asText("");
+        var completeName = (lot_type + " " + name).strip();
+        carPark.name = new NonLocalizedString(completeName);
 
         var coords = node.path("coords");
         carPark.x = coords.path("lng").asDouble();
@@ -38,14 +42,18 @@ public class ParkApiDataSource extends GenericJsonCarParkDataSource{
 
         carPark.spacesAvailable = node.path("free").asInt(Integer.MAX_VALUE);
         carPark.maxCapacity = node.path("total").asInt(Integer.MAX_VALUE);
-        carPark.realTimeData = true;
+        carPark.realTimeData = isRealTimeData(carPark, node.path("state").asText());
 
         carPark.geometry = gf.createPoint(new Coordinate(carPark.x, carPark.y));
 
-        carPark.openingHours = node.path("opening_hours").asText();
+        carPark.openingHours = node.path("opening_hours").asText(null);
         carPark.url = node.path("url").asText(null);
 
         return carPark;
+    }
+
+    private static boolean isRealTimeData(CarPark carPark, String parkApiState) {
+        return carPark.spacesAvailable != Integer.MAX_VALUE && "nodata".equals(parkApiState);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
@@ -28,11 +28,13 @@ public class ParkApiDataSource extends GenericJsonCarParkDataSource{
 
         var carPark = new CarPark();
         carPark.name = new NonLocalizedString(node.path("name").asText());
-        carPark.id = node.path("id").asText();
 
         var coords = node.path("coords");
         carPark.x = coords.path("lng").asDouble();
         carPark.y = coords.path("lat").asDouble();
+
+        var fallbackId = url + ":" + carPark.x + "," + carPark.y;
+        carPark.id = node.path("id").asText(fallbackId);
 
         carPark.spacesAvailable = node.path("/free").asInt(Integer.MAX_VALUE);
         carPark.maxCapacity = node.path("/total").asInt(Integer.MAX_VALUE);

--- a/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
+++ b/src/main/java/org/opentripplanner/updater/car_park/ParkApiDataSource.java
@@ -36,8 +36,8 @@ public class ParkApiDataSource extends GenericJsonCarParkDataSource{
         var fallbackId = url + ":" + carPark.x + "," + carPark.y;
         carPark.id = node.path("id").asText(fallbackId);
 
-        carPark.spacesAvailable = node.path("/free").asInt(Integer.MAX_VALUE);
-        carPark.maxCapacity = node.path("/total").asInt(Integer.MAX_VALUE);
+        carPark.spacesAvailable = node.path("free").asInt(Integer.MAX_VALUE);
+        carPark.maxCapacity = node.path("total").asInt(Integer.MAX_VALUE);
         carPark.realTimeData = true;
 
         carPark.geometry = gf.createPoint(new Coordinate(carPark.x, carPark.y));

--- a/src/main/resources/WayProperties.properties
+++ b/src/main/resources/WayProperties.properties
@@ -37,3 +37,5 @@ name.bicycle_parking=Bicycle parking
 name.park_and_ride_name=P+R {name}
 name.park_and_ride_station=P+R
 
+alert.car_park.full.header = Few parking spaces available
+alert.car_park.full.description = The selected car park has only few spaces available. Please add extra time to your trip.

--- a/src/main/resources/WayProperties_de.properties
+++ b/src/main/resources/WayProperties_de.properties
@@ -37,3 +37,6 @@ name.bicycle_parking=Fahrradabstellplatz
 
 name.park_and_ride_name=P+R {name}
 name.park_and_ride_station=P+R
+
+alert.car_park.full.header = Few parking spaces available
+alert.car_park.full.description = The selected car park has only few spaces available. Please add extra time to your trip.

--- a/src/main/resources/internals_de.properties
+++ b/src/main/resources/internals_de.properties
@@ -1,2 +1,4 @@
 corner = Kreuzung %s mit %s
 unnamedStreet = unbekannte Strasse
+fullCarParkAlertHeader = Few parking spaces available
+fullCarParkAlertDescription =

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -59,7 +59,7 @@
   <logger name="org.opentripplanner.updater.bike_rental.VilkkuBikeRentalDataSource" level="warn" />
   <logger name="org.opentripplanner.updater.bike_rental.NextBikeRentalDataSource" level="warn" />
   <logger name="org.opentripplanner.updater.bike_rental.BikeRentalUpdater" level="warn" />
-  <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource" level="info" />
+  <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource" level="error" />
   <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource$GtfsRealtimeStatistics" level="info" />
   <logger name="org.opentripplanner.routing.edgetype.Timetable" level="off" />
   <logger name="org.opentripplanner.routing.trippattern.TripTimes" level="off" />

--- a/src/test/java/org/opentripplanner/routing/car_park/CarParkTest.java
+++ b/src/test/java/org/opentripplanner/routing/car_park/CarParkTest.java
@@ -1,0 +1,30 @@
+package org.opentripplanner.routing.car_park;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.opentripplanner.routing.car_park.CarPark.hasFewSpacesAvailable;
+
+public class CarParkTest {
+
+    @Test
+    public void shouldCalculateFewSpacesAvailable() {
+        // easy cases
+        assertFalse(hasFewSpacesAvailable(99, 100));
+        assertTrue(hasFewSpacesAvailable(1, 100));
+
+        // low max capacity
+        assertFalse(hasFewSpacesAvailable(2, 11));
+        assertTrue(hasFewSpacesAvailable(1, 10));
+        assertTrue(hasFewSpacesAvailable(1, 9));
+        assertTrue(hasFewSpacesAvailable(1, 5));
+        assertTrue(hasFewSpacesAvailable(1, 1));
+
+        // high max capacity
+        assertFalse(hasFewSpacesAvailable(11, 100));
+        assertTrue(hasFewSpacesAvailable(20, 200));
+        assertFalse(hasFewSpacesAvailable(20, 201));
+        assertTrue(hasFewSpacesAvailable(19, 201));
+        assertFalse(hasFewSpacesAvailable(20, 500));
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
@@ -1,0 +1,152 @@
+package org.opentripplanner.routing.core;
+
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.opentripplanner.ConstantsForTests;
+import org.opentripplanner.api.model.TripPlan;
+import org.opentripplanner.api.parameter.QualifiedMode;
+import org.opentripplanner.api.resource.GraphPathToTripPlanConverter;
+import org.opentripplanner.common.model.GenericLocation;
+import org.opentripplanner.graph_builder.linking.SimpleStreetSplitter;
+import org.opentripplanner.routing.car_park.CarPark;
+import org.opentripplanner.routing.car_park.CarParkService;
+import org.opentripplanner.routing.edgetype.ParkAndRideEdge;
+import org.opentripplanner.routing.edgetype.ParkAndRideLinkEdge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.impl.GraphPathFinder;
+import org.opentripplanner.routing.spt.GraphPath;
+import org.opentripplanner.routing.vertextype.ParkAndRideVertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.standalone.Router;
+import org.opentripplanner.util.NonLocalizedString;
+import org.opentripplanner.util.PolylineEncoder;
+import org.opentripplanner.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.opentripplanner.routing.core.PolylineAssert.assertThatPolylinesAreEqual;
+
+public class CarParkRoutingTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CarParkRoutingTest.class);
+
+    static long dateTime = TestUtils.dateInSeconds("Europe/Berlin", 2020, 07, 9, 15, 0, 0);
+
+    Graph graph = getDefaultGraph();
+
+    static GeometryFactory gf = new GeometryFactory();
+
+    public static Graph getDefaultGraph() {
+        var graph = TestGraphBuilder.buildGraph(ConstantsForTests.HERRENBERG_OSM);
+        return addCarParksToGraph(graph);
+    }
+
+    private static Graph addCarParksToGraph(Graph graph) {
+        var carParks = ImmutableSet.of(
+                makeCarPark("1", "Goethestr.", 100, 48.59077, 8.86707)
+        );
+
+        var service = new CarParkService();
+        graph.putService(CarParkService.class, service);
+
+        carParks.forEach((CarPark carPark) -> {
+
+            var linker = new SimpleStreetSplitter(graph);
+            service.addCarPark(carPark);
+
+            var carParkVertex = new ParkAndRideVertex(graph, carPark);
+            new ParkAndRideEdge(carParkVertex);
+            var envelope = carPark.geometry.getEnvelopeInternal();
+            graph.streetIndex
+                    .getVerticesForEnvelope(envelope)
+                    .stream()
+                    .filter(vertex -> vertex instanceof StreetVertex)
+                    .filter(vertex -> gf.createPoint(vertex.getCoordinate()).within(carPark.geometry))
+                    .peek(vertex -> new ParkAndRideLinkEdge(vertex, carParkVertex))
+                    .forEach(vertex -> new ParkAndRideLinkEdge(carParkVertex, vertex));
+
+            if (!(linker.link(carParkVertex, TraverseMode.CAR, null) &&
+                    linker.link(carParkVertex, TraverseMode.WALK, null))) {
+                LOG.error("{} not near any streets; it will not be usable.", carPark);
+            }
+
+        });
+
+        return graph;
+    }
+
+    private static CarPark makeCarPark(String id, String name, int freeSpaces, double lat, double lon) {
+        var carPark = new CarPark();
+        carPark.y = lat;
+        carPark.x = lon;
+        carPark.geometry = gf.createPoint(new Coordinate(carPark.x, carPark.y));
+        carPark.spacesAvailable = freeSpaces;
+        carPark.maxCapacity = freeSpaces;
+        carPark.realTimeData = true;
+        carPark.id = id;
+        carPark.name = new NonLocalizedString(name);
+        return carPark;
+    }
+
+    private static String calculatePolyline(Graph graph, GenericLocation from, GenericLocation to) {
+        var plan = getTripPlan(graph, from, to);
+
+        return firstTripToPolyline(plan);
+    }
+
+    private static String firstTripToPolyline(TripPlan plan) {
+        Stream<List<Coordinate>> points = plan.itinerary.get(0).legs.stream().map(l -> PolylineEncoder.decode(l.legGeometry));
+        return PolylineEncoder.createEncodings(points.flatMap(List::stream).collect(Collectors.toList())).getPoints();
+    }
+
+    private static TripPlan getTripPlan(Graph graph, GenericLocation from, GenericLocation to) {
+        RoutingRequest request = new RoutingRequest();
+        request.dateTime = dateTime;
+        request.from = from;
+        request.to = to;
+
+        request.modes = new TraverseModeSet(TraverseMode.CAR, TraverseMode.WALK);
+        new QualifiedMode(TraverseMode.CAR, QualifiedMode.Qualifier.PARK).applyToRoutingRequest(request, false);
+        request.setRoutingContext(graph);
+        request.parkAndRide = true;
+
+        GraphPathFinder gpf = new GraphPathFinder(new Router(graph.routerId, graph));
+        List<GraphPath> paths = gpf.graphPathFinderEntryPoint(request);
+
+        TripPlan plan = GraphPathToTripPlanConverter.generatePlan(paths, request);
+
+        var legs = plan.itinerary.get(0).legs;
+        var firstLeg = legs.get(0);
+        assertEquals(firstLeg.mode, "CAR");
+        var lastLeg = legs.get(legs.size() - 1);
+        assertEquals(lastLeg.mode, "WALK");
+
+        return plan;
+    }
+
+    @Test
+    public void driveToStaticParkRide() {
+        var zwickauerStr = new GenericLocation(48.59473, 8.84661);
+        var walterKnollStr = new GenericLocation(48.59308, 8.86327);
+
+        var polyline = calculatePolyline(graph, zwickauerStr, walterKnollStr);
+        assertThatPolylinesAreEqual(polyline, "adrgHez~t@gAW_AO]KKEDcCDkCD{ABw@@_@FwC@S?[F}EK{DMoCEiB@_CLmEBaBFiDCuBGiAK_BYyEQoCEs@GuA?gA?]?_@FAbA]DElA_AJKRs@DQ?O\\ENDDJJ^DNPMTQDWC@AGCGl@e@LIXSVS@A?ONw@DI?CEg@LQ~@o@FKBGLNPv@");
+    }
+
+    @Test
+    public void driveToDynamicallyAddedCarPark() {
+        var zwickauerStr = new GenericLocation(48.59473, 8.84661);
+        var hölderlinStr = new GenericLocation(48.59140, 8.86790);
+
+        var polyline = calculatePolyline(graph, zwickauerStr, hölderlinStr);
+        assertThatPolylinesAreEqual(polyline, "adrgHez~t@gAW_AO]KKEDcCDkCD{ABw@@_@FwC@S?[F}EK{DMoCEiB@_CLmEBaBFiDCuBGiAK_BYyEQoCEs@GuA?gA?]?_@BuABaAb@uGBe@D_A?_AAaBAyA@m@?s@@cF@g@?k@@M@MBIBIHAF?D@FDB@HDFJHJLPHHJJj@n@PLLJNLPNp@p@NNNPJN`Au@^Sn@W`@Kj@Q`Cq@dBg@j@Il@Ed@?z@?A?{@?e@?[kD");
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
@@ -51,7 +51,9 @@ public class CarParkRoutingTest {
 
     private static Graph addCarParksToGraph(Graph graph) {
         var carParks = ImmutableSet.of(
-                makeCarPark("1", "Goethestr.", 100, 48.59077, 8.86707)
+                makeCarPark("1", "Goethestr.", 100, 48.59077, 8.86707),
+                makeCarPark("2", "Affstädter Tal", 0, 48.59978, 8.87140)
+
         );
 
         var service = new CarParkService();
@@ -148,5 +150,14 @@ public class CarParkRoutingTest {
 
         var polyline = calculatePolyline(graph, zwickauerStr, hölderlinStr);
         assertThatPolylinesAreEqual(polyline, "adrgHez~t@gAW_AO]KKEDcCDkCD{ABw@@_@FwC@S?[F}EK{DMoCEiB@_CLmEBaBFiDCuBGiAK_BYyEQoCEs@GuA?gA?]?_@BuABaAb@uGBe@D_A?_AAaBAyA@m@?s@@cF@g@?k@@M@MBIBIHAF?D@FDB@HDFJHJLPHHJJj@n@PLLJNLPNp@p@NNNPJN`Au@^Sn@W`@Kj@Q`Cq@dBg@j@Il@Ed@?z@?A?{@?e@?[kD");
+    }
+
+    @Test
+    public void driveToDynamicallyAddedCarParkEvenIfItHasZeroFreeSpaces() {
+        var nufringen = new GenericLocation(48.6225, 8.8884);
+        var benzStr = new GenericLocation(48.59878, 8.87175);
+
+        var polyline = calculatePolyline(graph, nufringen, benzStr);
+        assertThatPolylinesAreEqual(polyline, "arwgHg_gu@Hl@NRPL\\Rf@Lf@T`@Ln@NdBVd@VRHjAh@BBtE~BXLjClAj@XjAz@LLPR`BpCrF~Hv@bAd@n@f@r@l@hA`@bAJLJLFFHBN@JAJAAe@AY?U?S?a@@]@U@[BYBMFi@Fc@PgABSJo@DYrAf@hAb@j@^bBbArAxAjCrDhCpDDJvAbB~CvCTRNNVV`HfHxD|DrDtEx@bAzBpBh@b@NLzAp@`A\\n@RhA\\dAXLDzFrALDn@RVJtAf@~Av@hAz@Pv@l@n@K\\M\\KKEEAC??@BDDJJ`BpBVi@Tg@RQXg@b@{@WYYZA@");
     }
 }

--- a/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
@@ -56,7 +56,6 @@ public class CarParkRoutingTest {
         var carParks = ImmutableSet.of(
                 makeCarPark("1", "Goethestr.", 100, 100, 48.59077, 8.86707),
                 makeCarPark("2", "Affstädter Tal", 0, 100, 48.59978, 8.87140)
-
         );
 
         var service = new CarParkService();
@@ -142,7 +141,7 @@ public class CarParkRoutingTest {
 
         var tripPlan = getTripPlan(graph, now, zwickauerStr, walterKnollStr);
         var polyline = firstTripToPolyline(tripPlan);
-        assertThatPolylinesAreEqual(polyline, "adrgHez~t@gAW_AO]KKEDcCDkCD{ABw@@_@FwC@S?[F}EK{DMoCEiB@_CLmEBaBFiDCuBGiAK_BYyEQoCEs@GuA?gA?]?_@FAbA]DElA_AJKRs@DQ?O\\ENDDJJ^DNPMTQDWC@AGCGl@e@LIXSVS@A?ONw@DI?CEg@LQ~@o@FKBGLNPv@");
+        assertThatPolylinesAreEqual(polyline, "adrgHez~t@gAW_AO]KKEDcCDkCD{ABw@@_@FwC@S?[F}EK{DMoCEiB@_CLmEBaBFiDCuBGiAK_BYyEQoCEs@GuA?gA?]?_@FAbA]DElA_AJKRs@DQ?O\\ENDDJJ^DNPMTQDWC@AGCGNMFETQLIXSVS@A?OLw@FI?CEg@LQ~@o@FKBGLNPv@");
     }
 
     @Test
@@ -192,7 +191,7 @@ public class CarParkRoutingTest {
 
         var tripPlan = getTripPlan(graph, now, true, nufringen, benzStr);
         var polyline = firstTripToPolyline(tripPlan);
-        assertThatPolylinesAreEqual(polyline, "arwgHg_gu@Hl@NRPL\\Rf@Lf@T`@Ln@NdBVd@VRHjAh@BBtE~BXLjClAj@XjAz@LLPR`BpCrF~Hv@bAd@n@f@r@l@hA`@bAJLJLFFHBN@JAJABv@HxBB`@Bn@@l@?^?ZAp@An@Cn@Ej@E`@In@G^E^GXMh@Mh@M`@IXKVKZMXMVUb@U^OTQTORa@f@YZYZu@v@YZWZSTMPKNOTQVMVOZMTKXK\\IVIZI\\I^EZE\\Ed@Gv@Cf@?r@?d@@`@@b@D`@B`@B\\LzAH~@H~@Bp@Dn@D|@Bz@DlABnABlABjA@t@@v@@t@?t@@h@?h@?`AA~@?`AAh@@h@?h@?d@@~@B|@B`AD~@F`AH~AH~AHlAFlAFrADpAH|ABx@Dt@Dv@Dr@Fv@Ft@Db@DXD\\Hd@FXBNNn@J`@H\\^vAPl@Pn@Lj@Nl@Pn@Nn@Ll@Ll@Np@Nt@BLBZDZB\\@HEFCHCH?D?F?JBLDJDHHDF?@?HADCBC@ABGBG@I@IHEFCLGXOf@IXGXI~@Qd@KXGf@MRGVIPGRKRITKNKVOd@WRMTMRIRITINGVGRERCTATCV?T@T@P@TBRDTFPFTHNHNHLFNPNPDDDFBF?F?H@F@F@FBDDFDBD@D@F?DCDCHDHDNLRPJRHLHPJRJVRh@Vp@Rh@Rb@LXNVPZNRNPPRRPRPRLNJTJXLRFTFRBVBTBV?RARAPAXGREXKRGNIXORQPONMRSRWb@i@PU\\e@f@u@^m@`@g@NSPSVWNKLKTQVMVMRIPGVGd@Kn@KVGRG\\MRKXQZUPQRQRURSNQNORKJGHGFCDBFBH?B?BAFEDK@ABI@M?OCMEKEE?M?K?O?S@[BUDQDQDOHUHSLUTa@V]LUJQJSHQFQHUFUHUFWFYDWB]Dq@Bi@@m@B}B?cA?_D?o@h@?n@Cd@G\\ILAj@WdAo@v@e@^Ql@Y\\GXEX?F@r@B|@Jf@BdAGT?PIFAbA]DElA_AJKRs@DQ?Q\\ENDDJJ^DNPMTQA?UPQLEOK_@EKOE]DAQESSq@?CSo@GSI]O]]aAUe@A?GE?_AAaBAyA@m@?u@O@@aE?i@@_@?WIQGMGGGASGSIQEMEOKMIKGKIMKOOGIKMU[m@kA{@gBiAyBe@y@MSOWEGYe@[i@i@{@Wc@DSIUACGKGSGIXg@b@{@WYYZA@");
+        assertThatPolylinesAreEqual(polyline, "arwgHg_gu@Hl@NRPL\\Rf@Lf@T`@Ln@NdBVd@VRHjAh@BBtE~BXLjClAj@XjAz@LLPR`BpCrF~Hv@bAd@n@f@r@l@hA`@bAJLJLFFHBN@JAJABv@HxBB`@Bn@@l@?^?ZAp@An@Cn@Ej@E`@In@G^E^GXMh@Mh@M`@IXKVKZMXMVUb@U^OTQTORa@f@YZYZu@v@YZWZSTMPKNOTQVMVOZMTKXK\\IVIZI\\I^EZE\\Ed@Gv@Cf@?r@?d@@`@@b@D`@B`@B\\LzAH~@H~@Bp@Dn@D|@Bz@DlABnABlABjA@t@@v@@t@?t@@h@?h@?`AA~@?`AAh@@h@?h@?d@@~@B|@B`AD~@F`AH~AH~AHlAFlAFrADpAH|ABx@Dt@Dv@Dr@Fv@Ft@Db@DXD\\Hd@FXBNNn@J`@H\\^vAPl@Pn@Lj@Nl@Pn@Nn@Ll@Ll@Np@Nt@BLBZDZB\\@HEFCHCH?D?F?JBLDJDHHDF?@?HADCBC@ABGBG@I@IHEFCLGXOf@IXGXI~@Qd@KXGf@MRGVIPGRKRITKNKVOd@WRMTMRIRITINGVGRERCTATCV?T@T@P@TBRDTFPFTHNHNHLFNPNPDDDFBF?F?H@F@F@FBDDFDBD@D@F?DCDCHDHDNLRPJRHLHPJRJVRh@Vp@Rh@Rb@LXNVPZNRNPPRRPRPRLNJTJXLRFTFRBVBTBV?RARAPAXGREXKRGNIXORQPONMRSRWb@i@PU\\e@f@u@^m@`@g@NSPSVWNKLKTQVMVMRIPGVGd@Kn@KVGRG\\MRKXQZUPQRQRURSNQNORKJGHGFCDBFBH?B?BAFEDK@ABI@M?OCMEKEE?M?K?O?S@[BUDQDQDOHUHSLUTa@V]LUJQJSHQFQHUFUHUFWFYDWB]Dq@Bi@@m@B}B?cA?_D?o@h@?n@Cd@G\\ILAj@WdAo@v@e@^Ql@Y\\GXEX?F@r@B|@Jf@BdAGT?PIFAbA]DElA_AJKRs@DQ?Q\\ENDDJJ^DNPMTQDWC@AGCG?ECCEGm@TEDOE]DAQESSq@?CSo@GSI]O]]aAUe@A?GE?_AAaBAyA@m@?u@O@@aE?i@@_@?WIQGMGGGASGSIQEMEOKMIKGKIMKOOGIKMU[m@kA{@gBiAyBe@y@MSOWEGYe@[i@i@{@Wc@DSIUACGKGSGIXg@b@{@WYYZA@");
 
         assertNull(tripPlan.itinerary.get(0).legs.get(0).alerts);
     }

--- a/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/CarParkRoutingTest.java
@@ -166,7 +166,9 @@ public class CarParkRoutingTest {
         var polyline = firstTripToPolyline(tripPlan);
         assertThatPolylinesAreEqual(polyline, "arwgHg_gu@Hl@NRPL\\Rf@Lf@T`@Ln@NdBVd@VRHjAh@BBtE~BXLjClAj@XjAz@LLPR`BpCrF~Hv@bAd@n@f@r@l@hA`@bAJLJLFFHBN@JAJAAe@AY?U?S?a@@]@U@[BYBMFi@Fc@PgABSJo@DYrAf@hAb@j@^bBbArAxAjCrDhCpDDJvAbB~CvCTRNNVV`HfHxD|DrDtEx@bAzBpBh@b@NLzAp@`A\\n@RhA\\dAXLDzFrALDn@RVJtAf@~Av@hAz@Pv@l@n@K\\M\\KKEEAC??@BDDJJ`BpBVi@Tg@RQXg@b@{@WYYZA@");
 
-        assertEquals(tripPlan.itinerary.get(0).legs.get(0).alerts.get(0).getAlertUrl(), "alert:carpark:few-spaces-available");
+        var alert = tripPlan.itinerary.get(0).legs.get(0).alerts.get(0);
+        assertEquals("Few parking spaces available", alert.getAlertHeaderText());
+        assertEquals("The selected car park has only few spaces available. Please add extra time to your trip.", alert.getAlertDescriptionText());
     }
 
     @Test

--- a/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.updater.car_park;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import java.util.stream.Collectors;

--- a/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
@@ -1,0 +1,36 @@
+package org.opentripplanner.updater.car_park;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class ParkApiDataSourceTest {
+
+    @Test
+    public void testParser() {
+        ParkApiDataSource source = new ParkApiDataSource();
+        source.setUrl("file:src/test/resources/park_api.json");
+        assertTrue(source.update());
+        var carParks = source.getCarParks();
+
+        assertEquals(19, carParks.size());
+
+        carParks.forEach(lot -> assertNotNull(lot.geometry));
+
+        var first = carParks.get(0);
+        assertEquals(Integer.MAX_VALUE, first.spacesAvailable);
+        assertEquals(Integer.MAX_VALUE, first.maxCapacity);
+
+        var epsilon = 0.02;
+        assertEquals(8.865461, first.x, epsilon);
+        assertEquals(48.596319, first.y, epsilon);
+
+        var urls = carParks.stream().map(p -> p.url).collect(Collectors.toList());
+        assertEquals(urls.get(0), "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1016");
+        assertNull(urls.get(urls.size() - 1));
+    }
+
+}

--- a/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
@@ -19,6 +19,11 @@ public class ParkApiDataSourceTest {
 
         carParks.forEach(lot -> assertNotNull(lot.geometry));
 
+        carParks.forEach(lot -> {
+            assertNotNull(lot.id);
+            assertNotEquals("", lot.id);
+        });
+
         var first = carParks.get(0);
         assertEquals(Integer.MAX_VALUE, first.spacesAvailable);
         assertEquals(Integer.MAX_VALUE, first.maxCapacity);

--- a/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
@@ -29,13 +29,13 @@ public class ParkApiDataSourceTest {
         assertEquals(58, first.maxCapacity);
 
         var obererGraben = carParks.get(2);
-        assertEquals("Oberer Graben", obererGraben.name.toString());
+        assertEquals("Parkplatz Oberer Graben", obererGraben.name.toString());
         assertEquals(6, obererGraben.spacesAvailable);
         assertEquals(24, obererGraben.maxCapacity);
         assertFalse(obererGraben.hasFewSpacesAvailable());
 
         var cattleAuctionHall = carParks.get(16);
-        assertEquals("Viehversteigerungshalle", cattleAuctionHall.name.toString());
+        assertEquals("Parkplatz Viehversteigerungshalle", cattleAuctionHall.name.toString());
         assertEquals(8, cattleAuctionHall.spacesAvailable);
         assertEquals(95, cattleAuctionHall.maxCapacity);
         assertTrue(cattleAuctionHall.hasFewSpacesAvailable());

--- a/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
+++ b/src/test/java/org/opentripplanner/updater/car_park/ParkApiDataSourceTest.java
@@ -26,7 +26,19 @@ public class ParkApiDataSourceTest {
 
         var first = carParks.get(0);
         assertEquals(Integer.MAX_VALUE, first.spacesAvailable);
-        assertEquals(Integer.MAX_VALUE, first.maxCapacity);
+        assertEquals(58, first.maxCapacity);
+
+        var obererGraben = carParks.get(2);
+        assertEquals("Oberer Graben", obererGraben.name.toString());
+        assertEquals(6, obererGraben.spacesAvailable);
+        assertEquals(24, obererGraben.maxCapacity);
+        assertFalse(obererGraben.hasFewSpacesAvailable());
+
+        var cattleAuctionHall = carParks.get(16);
+        assertEquals("Viehversteigerungshalle", cattleAuctionHall.name.toString());
+        assertEquals(8, cattleAuctionHall.spacesAvailable);
+        assertEquals(95, cattleAuctionHall.maxCapacity);
+        assertTrue(cattleAuctionHall.hasFewSpacesAvailable());
 
         var epsilon = 0.02;
         assertEquals(8.865461, first.x, epsilon);

--- a/src/test/resources/park_api.json
+++ b/src/test/resources/park_api.json
@@ -229,6 +229,7 @@
         "lng": 8.86822
       },
       "total": 95,
+      "free": 8,
       "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1025"
     },
     {

--- a/src/test/resources/park_api.json
+++ b/src/test/resources/park_api.json
@@ -1,0 +1,261 @@
+{
+  "data_source": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze",
+  "last_downloaded": "2020-07-08T11:58:24.466582",
+  "last_updated": "2020-07-08T11:58:24.466582",
+  "lots": [
+    {
+      "lot_type": "Parkplatz",
+      "address": "Aischbachstraße",
+      "name": "Aischbachstraße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.596319,
+        "lng": 8.865461
+      },
+      "total": 58,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1016"
+    },
+    {
+      "lot_type": "Parkhaus",
+      "address": "Altstadtgarage",
+      "name": "Altstadtgarage",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.593768,
+        "lng": 8.872705
+      },
+      "total": 97,
+      "url": "https://stadtwerke.herrenberg.de/oepnv-parken/parken/sicher-und-zentral-parken/parkhaeuser-und-parkgebuehren/altstadtgarage/"
+    },
+    {
+      "id": "946955a0-a5bb-11ea-8d72-81c79f744047",
+      "lot_type": "Parkplatz",
+      "address": "Oberer Graben",
+      "name": "Oberer Graben",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59502,
+        "lng": 8.87029
+      },
+      "total": 24,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1002",
+      "opening_hours": "Mo - Su 00:00-24:00; PH 00:00-24:00",
+      "free": 6
+    },
+    {
+      "id": "5c4224c0-0a0e-11ea-9bc9-896973774264",
+      "lot_type": "Parkplatz",
+      "address": "Unterer Graben",
+      "name": "Unterer Graben",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59518,
+        "lng": 8.86898
+      },
+      "total": 39,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1002",
+      "opening_hours": "Mo,We,Th,Fr,Su 00:00-24:00; Tu,Sa 00:00-02:00, 14:30-24:00; PH 00:00-24:00",
+      "free": 24
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Kurzzeitparkplätze Bahnhofstraße",
+      "name": "Kurzzeitparkplätze Bahnhofstraße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.593634,
+        "lng": 8.863247
+      },
+      "total": 47,
+      "url": "https://stadtwerke.herrenberg.de/oepnv-parken/parken/sicher-und-zentral-parken/parkhaeuser-und-parkgebuehren/kurzzeitparkplaetze-bahnhofstrasse/"
+    },
+    {
+      "lot_type": "Park-Ride",
+      "address": "P+R Bahnhofstraße",
+      "name": "P+R Bahnhofstraße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59309,
+        "lng": 8.86126
+      },
+      "total": 122,
+      "url": "https://www.dbbahnpark.de/standorte/karte/parkplatz-bahnhof-herrenberg/"
+    },
+    {
+      "lot_type": "Tiefgarage",
+      "address": "Bronntor",
+      "name": "Bronntor",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.596636,
+        "lng": 8.867949
+      },
+      "total": 90,
+      "url": "https://stadtwerke.herrenberg.de/oepnv-parken/parken/sicher-und-zentral-parken/parkhaeuser-und-parkgebuehren/bronntor-tiefgarage/",
+      "opening_hours": "Mo-Fr 07:30-22:00; Sa 07:30-18:00; PH off"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Gültsteiner Straße",
+      "name": "Gültsteiner Straße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.594364,
+        "lng": 8.871189
+      },
+      "total": 69,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1022"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Hasenplatz",
+      "name": "Hasenplatz",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.594601,
+        "lng": 8.872216
+      },
+      "total": 20,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1021"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Horber Straße/Nagolder Straße",
+      "name": "Horber Straße/Nagolder Straße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.595168,
+        "lng": 8.866325
+      },
+      "total": 36,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1017"
+    },
+    {
+      "lot_type": "Parkhaus",
+      "address": "Nufringer Tor",
+      "name": "Nufringer Tor",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.597865,
+        "lng": 8.870266
+      },
+      "total": 242,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1012"
+    },
+    {
+      "lot_type": "Park-Ride",
+      "address": "P+R Kalkofenstraße",
+      "name": "P+R Kalkofenstraße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59403,
+        "lng": 8.8615
+      },
+      "total": 398,
+      "url": "https://stadtwerke.herrenberg.de/oepnv-parken/parken/sicher-und-zentral-parken/parkhaeuser-und-parkgebuehren/p-r-parkhaus/"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Seelesplatz",
+      "name": "Seelesplatz",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.597414,
+        "lng": 8.86927
+      },
+      "total": 27,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1014"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Stadthalle",
+      "name": "Stadthalle",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.599227,
+        "lng": 8.869871
+      },
+      "total": 211,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1006"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Volksbank",
+      "name": "Volksbank",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59435,
+        "lng": 8.869386
+      },
+      "total": 47,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1020"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Wilhelmstraße",
+      "name": "Wilhelmstraße",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.595431,
+        "lng": 8.874739
+      },
+      "total": 18,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1023"
+    },
+    {
+      "lot_type": "Parkplatz",
+      "address": "Viehversteigerungshalle",
+      "name": "Viehversteigerungshalle",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59946,
+        "lng": 8.86822
+      },
+      "total": 95,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Service/Parkplaetze/Parkplatz?view=publish&item=parkingLocation&id=1025"
+    },
+    {
+      "lot_type": "Wohnmobilparkplatz",
+      "address": "Wohnmobilhafen Herrenberg",
+      "name": "Wohnmobilhafen Herrenberg",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.59019,
+        "lng": 8.87751
+      },
+      "total": 10,
+      "free": 0,
+      "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Tourismus-Gaeste/uebernachten/Wohnmobilstellplaetze"
+    },
+    {
+      "lot_type": "Park-Carpool",
+      "address": "Parken + Mitfahren A81/B296",
+      "name": "Parken + Mitfahren A81/B296",
+      "forecast": false,
+      "state": "nodata",
+      "coords": {
+        "lat": 48.5807,
+        "lng": 8.9022
+      },
+      "total": 10
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds an updater that dynamically adds car park using the ParkAPI format.

By default it completely ignores the available spaces in the car park and adds an alert instead.

However, you can also add take them into account and exclude full ones from the search result by setting the request parameter `useCarParkAvailabilityInformation = true`.