### PR TITLE
Handle CARPOOL in the legacy GraphQL API

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLTypes.java
@@ -417,6 +417,7 @@ public class LegacyGraphQLTypes {
         Bus("BUS"),
         CableCar("CABLE_CAR"),
         Car("CAR"),
+        Carpool("CARPOOL"),
         Ferry("FERRY"),
         Flexible("FLEXIBLE"),
         Funicular("FUNICULAR"),

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -850,6 +850,9 @@ enum Mode {
     """CAR"""
     CAR
 
+    """CARPOOL"""
+    CARPOOL
+
     """FERRY"""
     FERRY
 


### PR DESCRIPTION
This _should_ handle the CARPOOL mode in the GraphQL API, but I haven't tested yet since I don't have the GraphQL things set up locally.

Regenerating the generated files using the instructions in the README.md work using `yarn`, but produced significantly differing files compared to what is currently commited. Because of this I copied the relevant changes over manually.

#65 