### PR TITLE
Backward compatible handling of multiple on-street modes

### DIFF
--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSet.java
@@ -9,7 +9,10 @@ import org.opentripplanner.routing.api.request.StreetMode;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * A set of qualified modes. The original intent was to allow a sequence of mode sets, but the shift to "long distance
@@ -83,8 +86,32 @@ public class QualifiedModeSet implements Serializable {
         //   redesigned to better reflect the mode structure used in RequestModes.
         //   Also, some StreetModes are implied by combination of QualifiedModes and are not covered
         //   in this mapping.
-        for (QualifiedMode qMode : qModes) {
-            switch (qMode.mode) {
+        QualifiedMode requestMode = null;
+
+        List<QualifiedMode> filteredModes = qModes.stream()
+                .filter(m ->
+                        m.mode == ApiRequestMode.WALK ||
+                        m.mode == ApiRequestMode.BICYCLE ||
+                        m.mode == ApiRequestMode.CAR)
+                .collect(Collectors.toList());
+
+        if (filteredModes.size() > 1) {
+            List<QualifiedMode> filteredModesWithoutWalk = filteredModes.stream()
+                    .filter(Predicate.not(m -> m.mode == ApiRequestMode.WALK))
+                    .collect(Collectors.toList());
+            if (filteredModesWithoutWalk.size() > 1) {
+                throw new IllegalStateException("Multiple non-walk modes provided " + filteredModesWithoutWalk);
+            } else if (filteredModesWithoutWalk.isEmpty()) {
+                requestMode = filteredModes.get(0);
+            } else {
+                requestMode = filteredModesWithoutWalk.get(0);
+            }
+        } else if (!filteredModes.isEmpty()) {
+            requestMode = filteredModes.get(0);
+        }
+
+        if(requestMode != null) {
+            switch (requestMode.mode) {
                 case WALK:
                     accessMode = StreetMode.WALK;
                     transferMode = StreetMode.WALK;
@@ -92,19 +119,17 @@ public class QualifiedModeSet implements Serializable {
                     directMode = StreetMode.WALK;
                     break;
                 case BICYCLE:
-                    if (qMode.qualifiers.contains(Qualifier.RENT)) {
+                    if (requestMode.qualifiers.contains(Qualifier.RENT)) {
                         accessMode = StreetMode.BIKE_RENTAL;
                         transferMode = StreetMode.BIKE_RENTAL;
                         egressMode = StreetMode.BIKE_RENTAL;
                         directMode = StreetMode.BIKE_RENTAL;
-                    }
-                    else if (qMode.qualifiers.contains(Qualifier.PARK)) {
+                    } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
                         accessMode = StreetMode.BIKE_TO_PARK;
                         transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.BIKE_TO_PARK;
-                    }
-                    else {
+                    } else {
                         accessMode = StreetMode.BIKE;
                         transferMode = StreetMode.BIKE;
                         egressMode = StreetMode.BIKE;
@@ -112,31 +137,27 @@ public class QualifiedModeSet implements Serializable {
                     }
                     break;
                 case CAR:
-                    if (qMode.qualifiers.contains(Qualifier.RENT)) {
+                    if (requestMode.qualifiers.contains(Qualifier.RENT)) {
                         accessMode = StreetMode.CAR_RENTAL;
                         transferMode = StreetMode.CAR_RENTAL;
                         egressMode = StreetMode.CAR_RENTAL;
                         directMode = StreetMode.CAR_RENTAL;
-                    }
-                    else if (qMode.qualifiers.contains(Qualifier.PARK)) {
+                    } else if (requestMode.qualifiers.contains(Qualifier.PARK)) {
                         accessMode = StreetMode.CAR_TO_PARK;
                         transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.CAR_TO_PARK;
-                    }
-                    else if (qMode.qualifiers.contains(Qualifier.PICKUP)) {
+                    } else if (requestMode.qualifiers.contains(Qualifier.PICKUP)) {
                         accessMode = StreetMode.WALK;
                         transferMode = StreetMode.WALK;
                         egressMode = StreetMode.CAR_PICKUP;
                         directMode = StreetMode.CAR_PICKUP;
-                    }
-                    else if (qMode.qualifiers.contains(Qualifier.DROPOFF)) {
+                    } else if (requestMode.qualifiers.contains(Qualifier.DROPOFF)) {
                         accessMode = StreetMode.CAR_PICKUP;
                         transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;
                         directMode = StreetMode.CAR_PICKUP;
-                    }
-                    else {
+                    } else {
                         accessMode = StreetMode.WALK;
                         transferMode = StreetMode.WALK;
                         egressMode = StreetMode.WALK;

--- a/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RequestModes.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.api.request;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.opentripplanner.model.TransitMode;
 
 import java.util.Arrays;
@@ -41,5 +42,28 @@ public class RequestModes {
         streetMode.equals(accessMode)
             || streetMode.equals(egressMode)
             || streetMode.equals(directMode);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    RequestModes that = (RequestModes) o;
+
+    if (accessMode != that.accessMode) return false;
+    if (egressMode != that.egressMode) return false;
+    if (directMode != that.directMode) return false;
+    return transitModes != null ? transitModes.equals(that.transitModes) : that.transitModes == null;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+            .append("accessMode", accessMode)
+            .append("egressMode", egressMode)
+            .append("directMode", directMode)
+            .append("transitModes", transitModes)
+            .toString();
   }
 }

--- a/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
+++ b/src/test/java/org/opentripplanner/api/parameter/QualifiedModeSetTest.java
@@ -1,0 +1,101 @@
+package org.opentripplanner.api.parameter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opentripplanner.routing.api.request.StreetMode.BIKE;
+import static org.opentripplanner.routing.api.request.StreetMode.BIKE_RENTAL;
+import static org.opentripplanner.routing.api.request.StreetMode.BIKE_TO_PARK;
+import static org.opentripplanner.routing.api.request.StreetMode.FLEXIBLE;
+import static org.opentripplanner.routing.api.request.StreetMode.WALK;
+
+import java.util.Set;
+import javax.ws.rs.BadRequestException;
+import org.junit.Test;
+import org.opentripplanner.routing.api.request.RequestModes;
+
+public class QualifiedModeSetTest {
+    @Test
+    public void emptyModeSet() {
+        assertThrows(BadRequestException.class, () -> new QualifiedModeSet(""));
+    }
+
+    @Test
+    public void singleWalk() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK");
+        assertEquals(Set.of(new QualifiedMode("WALK")), modeSet.qModes);
+        assertEquals(new RequestModes(WALK, WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void multipleWalks() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK,WALK,WALK");
+        assertEquals(Set.of(new QualifiedMode("WALK")), modeSet.qModes);
+        assertEquals(new RequestModes(WALK, WALK, WALK, WALK, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void singleWalkAndBicycle() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK,BICYCLE");
+        assertEquals(Set.of(
+                new QualifiedMode("WALK"),
+                new QualifiedMode("BICYCLE")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(BIKE, BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void singleWalkAndBicycleRental() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK,BICYCLE_RENT");
+        assertEquals(Set.of(
+                new QualifiedMode("WALK"),
+                new QualifiedMode("BICYCLE_RENT")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(BIKE_RENTAL, WALK, BIKE_RENTAL, BIKE_RENTAL, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void singleWalkAndBicycleToPark() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK,BICYCLE_PARK");
+        assertEquals(Set.of(
+                new QualifiedMode("WALK"),
+                new QualifiedMode("BICYCLE_PARK")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(BIKE_TO_PARK, WALK, WALK, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void multipleWalksAndBicycle() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("WALK,BICYCLE,WALK");
+        assertEquals(Set.of(
+                new QualifiedMode("WALK"),
+                new QualifiedMode("BICYCLE")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(BIKE, BIKE, BIKE, BIKE, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void multipleNonWalkModes() {
+        assertThrows(IllegalStateException.class, () -> new QualifiedModeSet("WALK,BICYCLE,CAR").getRequestModes());
+    }
+
+    @Test
+    public void allFlexible() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("FLEX_ACCESS,FLEX_EGRESS,FLEX_DIRECT");
+        assertEquals(Set.of(
+                new QualifiedMode("FLEX_DIRECT"),
+                new QualifiedMode("FLEX_EGRESS"),
+                new QualifiedMode("FLEX_ACCESS")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(FLEXIBLE, WALK, FLEXIBLE, FLEXIBLE, Set.of()), modeSet.getRequestModes());
+    }
+
+    @Test
+    public void bicycleToParkWithFlexibleEgress() {
+        QualifiedModeSet modeSet = new QualifiedModeSet("BICYCLE_PARK,FLEX_EGRESS");
+        assertEquals(Set.of(
+                new QualifiedMode("FLEX_EGRESS"),
+                new QualifiedMode("BICYCLE_PARK")
+        ), modeSet.qModes);
+        assertEquals(new RequestModes(BIKE_TO_PARK, WALK, FLEXIBLE, BIKE_TO_PARK, Set.of()), modeSet.getRequestModes());
+    }
+}


### PR DESCRIPTION
This is needed for OTP1 / OTP2 compatibility, so that having an "extra" `WALK` doesn't cause problems in OTP2.