### PR TITLE
Simplify no-thru traffic handling

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/edgetype/FlexTripEdge.java
@@ -1,8 +1,6 @@
 package org.opentripplanner.ext.flex.edgetype;
 
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPath;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.template.FlexAccessEgressTemplate;
@@ -56,7 +54,7 @@ public class FlexTripEdge extends Edge {
     int timeInSeconds = getTimeInSeconds();
     editor.incrementTimeInSeconds(timeInSeconds);
     editor.incrementWeight(timeInSeconds);
-    editor.resetEnteredMotorVerhicleNoThroughTrafficArea();
+    editor.resetEnteredNoThroughTrafficArea();
     return editor.makeState();
   }
 

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -625,12 +625,8 @@ public class State implements Cloneable {
         return reverse();
     }
 
-    boolean hasEnteredMotorVehicleNoThruTrafficArea() {
-        return stateData.enteredMotorVehicleNoThroughTrafficArea;
-    }
-
-    public boolean hasEnteredBicycleNoThruTrafficArea() {
-        return stateData.enteredBicycleNoThroughTrafficArea;
+    public boolean hasEnteredNoThruTrafficArea() {
+        return stateData.enteredNoThroughTrafficArea;
     }
 
     public boolean mayKeepRentedBicycleAtDestination() {

--- a/src/main/java/org/opentripplanner/routing/core/StateData.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateData.java
@@ -58,8 +58,7 @@ public class StateData implements Cloneable {
     public Set<String> bikeRentalNetworks;
 
     /* This boolean is set to true upon transition from a normal street to a no-through-traffic street. */
-    protected boolean enteredMotorVehicleNoThroughTrafficArea;
-    protected boolean enteredBicycleNoThroughTrafficArea;
+    protected boolean enteredNoThroughTrafficArea;
 
     public StateData(RoutingRequest options) {
         TraverseModeSet modes = options.streetSubRequestModes;

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -182,16 +182,20 @@ public class StateEditor {
 
     /* Basic Setters */
 
-    public void setEnteredMotorVerhicleNoThroughTrafficArea() {
-        child.stateData.enteredMotorVehicleNoThroughTrafficArea = true;
+    public void resetEnteredNoThroughTrafficArea() {
+        if (child.stateData.enteredNoThroughTrafficArea)
+            return;
+
+        cloneStateDataAsNeeded();
+        child.stateData.enteredNoThroughTrafficArea = false;
     }
 
-    public void resetEnteredMotorVerhicleNoThroughTrafficArea() {
-        child.stateData.enteredMotorVehicleNoThroughTrafficArea = true;
-    }
+    public void setEnteredNoThroughTrafficArea() {
+        if (child.stateData.enteredNoThroughTrafficArea)
+            return;
 
-    public void setEnteredBicycleNoThroughTrafficArea() {
-        child.stateData.enteredBicycleNoThroughTrafficArea = true;
+        cloneStateDataAsNeeded();
+        child.stateData.enteredNoThroughTrafficArea = true;
     }
 
     public void setBackMode(TraverseMode mode) {
@@ -357,24 +361,6 @@ public class StateEditor {
     private void cloneStateDataAsNeeded() {
         if (child.backState != null && child.stateData == child.backState.stateData)
             child.stateData = child.stateData.clone();
-    }
-
-    public void setOptions(RoutingRequest options) {
-        cloneStateDataAsNeeded();
-        child.stateData.opt = options;
-    }
-
-    public void setBikeRentalNetwork(Set<String> networks) {
-        cloneStateDataAsNeeded();
-        child.stateData.bikeRentalNetworks = networks;
-    }
-
-    public boolean hasEnteredMotorVehicleNoThroughTrafficArea() {
-        return child.hasEnteredMotorVehicleNoThruTrafficArea();
-    }
-
-    public boolean hasEnteredBicycleNoThroughTrafficArea() {
-        return child.hasEnteredBicycleNoThruTrafficArea();
     }
 
     public void addTimeRestriction(TimeRestrictionWithOffset timeRestriction, Object source) {

--- a/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
+++ b/src/main/java/org/opentripplanner/routing/spt/DominanceFunction.java
@@ -59,6 +59,10 @@ public abstract class DominanceFunction implements Serializable {
             return false;
         }
 
+        if (a.hasEnteredNoThruTrafficArea() != b.hasEnteredNoThruTrafficArea()) {
+            return false;
+        }
+
         /*
          * When creating AccessEgress paths for RAPTOR states with have different time restrictions
          * have to be considered, since a non-optimal VehicleParking could be used after the optimal


### PR DESCRIPTION
These changes seem reasonable, don't break any existing tests, but no new ones are added. Not copying `stateDate` when setting the no-thru state _might_ be the cause of subtle bugs, where depending on the edge traversal order routing could fail.

The code
* merges the no-thru state for bicycles / motor vehicles (in `State`)
* copies `stateData` when modifying the no-thru state
* handles no-thru state dominance using `DominanceFunction`