### PR TITLE
Correct the display of flex legs

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexLegMapper.java
@@ -27,7 +27,7 @@ public class FlexLegMapper {
     }
 
     public static void addFlexPlaces(Leg leg, FlexTripEdge flexEdge, Locale requestedLocale) {
-        leg.from = Place.forStop(flexEdge.s1, flexEdge.flexTemplate.fromStopIndex, null);
-        leg.to = Place.forStop(flexEdge.s2, flexEdge.flexTemplate.toStopIndex, null);
+        leg.from = Place.forFlexStop(flexEdge.s1, flexEdge.getFromVertex(), flexEdge.flexTemplate.fromStopIndex, null);
+        leg.to = Place.forFlexStop(flexEdge.s2, flexEdge.getToVertex(), flexEdge.flexTemplate.toStopIndex, null);
     }
 }

--- a/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/FlexRouter.java
@@ -2,6 +2,7 @@ package org.opentripplanner.ext.flex;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import java.util.Locale;
 import org.opentripplanner.common.model.T2;
 import org.opentripplanner.ext.flex.flexpathcalculator.FlexPathCalculator;
 import org.opentripplanner.ext.flex.flexpathcalculator.StreetFlexPathCalculator;
@@ -88,7 +89,7 @@ public class FlexRouter {
     }
   }
 
-  public Collection<Itinerary> createFlexOnlyItineraries() {
+  public Collection<Itinerary> createFlexOnlyItineraries(Locale locale) {
     calculateFlexAccessTemplates();
     calculateFlexEgressTemplates();
 
@@ -103,7 +104,7 @@ public class FlexRouter {
       StopLocation transferStop = template.getTransferStop();
       if (this.flexEgressTemplates.stream().anyMatch(t -> t.getAccessEgressStop().equals(transferStop))) {
         for(NearbyStop egress : streetEgressByStop.get(transferStop)) {
-          Itinerary itinerary = template.createDirectItinerary(egress, arriveBy, departureTime, startOfTime);
+          Itinerary itinerary = template.createDirectItinerary(egress, arriveBy, departureTime, startOfTime, locale);
           if (itinerary != null) {
             itineraries.add(itinerary);
           }

--- a/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
+++ b/src/ext/java/org/opentripplanner/ext/flex/template/FlexAccessTemplate.java
@@ -32,7 +32,8 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
   }
 
   public Itinerary createDirectItinerary(
-      NearbyStop egress, boolean arriveBy, int departureTime, ZonedDateTime startOfTime
+          NearbyStop egress, boolean arriveBy, int departureTime, ZonedDateTime startOfTime,
+          Locale locale
   ) {
     List<Edge> egressEdges = egress.edges;
 
@@ -89,7 +90,7 @@ public class FlexAccessTemplate extends FlexAccessEgressTemplate {
 
     Itinerary itinerary = GraphPathToItineraryMapper.generateItinerary(
         new GraphPath(state),
-        Locale.ENGLISH
+        locale
     );
 
     ZonedDateTime zdt = startOfTime.plusSeconds(timeShift);

--- a/src/main/java/org/opentripplanner/model/plan/Place.java
+++ b/src/main/java/org/opentripplanner/model/plan/Place.java
@@ -136,6 +136,22 @@ public class Place {
                 .build();
     }
 
+    public static Place forFlexStop(
+            StopLocation stop,
+            Vertex vertex,
+            Integer stopIndex,
+            Integer stopSequence
+    ) {
+        // The actual vertex is used because the StopLocation coordinates may not be equal to the vertex's
+        // coordinates.
+        return defaults(vertex, stop.getName())
+                .vertexType(VertexType.TRANSIT)
+                .stop(stop)
+                .stopIndex(stopIndex)
+                .stopSequence(stopSequence)
+                .build();
+    }
+
     public static Place forStop(TransitStopVertex vertex, String name) {
         return defaults(vertex, name)
                 .vertexType(VertexType.TRANSIT)

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -202,13 +202,18 @@ public abstract class GraphPathToItineraryMapper {
         int[] legIndexPairs = {0, states.length - 1};
         List<int[]> legsIndexes = new ArrayList<int[]>();
 
+        TraverseMode lastMode = null;
         for (int i = 1; i < states.length - 1; i++) {
             var backState = states[i];
             var forwardState = states[i + 1];
             var backMode = backState.getBackMode();
             var forwardMode = forwardState.getBackMode();
 
-            var modeChange = backMode != forwardMode && backMode != null && forwardMode != null;
+            if (backMode != null) {
+                lastMode = backMode;
+            }
+
+            var modeChange = lastMode != forwardMode && lastMode != null && forwardMode != null;
             var parkingChange = backState.isVehicleParked() != forwardState.isVehicleParked();
             var rentalChange = isRentalPickUp(backState) || isRentalDropOff(backState);
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectFlexRouter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/raptor/router/street/DirectFlexRouter.java
@@ -49,7 +49,7 @@ public class DirectFlexRouter {
               egressStops
       );
 
-      return new ArrayList<>(flexRouter.createFlexOnlyItineraries());
+      return new ArrayList<>(flexRouter.createFlexOnlyItineraries(request.locale));
     }
   }
 }


### PR DESCRIPTION
When creating itineraries for flex trips:
 * use the actual board / alight coordinates in leg.from / leg.to
 * correctly create new legs for mode transitions

This should fix the leg splitting mentioned in https://github.com/stadtnavi/digitransit-ui/issues/571