### PR TITLE
GTFS-rt - skip updates which may cause problems

### DIFF
--- a/src/main/java/org/opentripplanner/model/Timetable.java
+++ b/src/main/java/org/opentripplanner/model/Timetable.java
@@ -340,6 +340,14 @@ public class Timetable implements Serializable {
                                 newTimes.updateDepartureDelay(i, delay);
                             }
                         }
+                        if (newTimes.getDepartureTime(i) < newTimes.getArrivalTime(i)) {
+                            LOG.warn("Departure time at index {} is earlier then the arrival time for {}", i, newTimes.trip.getId());
+                            return null;
+                        }
+                        if (i > 0 && newTimes.getArrivalTime(i) <= newTimes.getDepartureTime(i - 1)) {
+                            LOG.warn("Arrival time at index {} is earlier or equal to the previous departure time for {}", i, newTimes.trip.getId());
+                            return null;
+                        }
                     }
 
                     if (updates.hasNext()) {

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -33,7 +33,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      * beginning of the trip and may or may not cover the entire trip. Partially canceling a trip in
      * this way is specifically not allowed.
      */
-    public static final int UNAVAILABLE = -1;
+    public static final int UNAVAILABLE = Integer.MIN_VALUE;
 
     /**
      * This allows re-using the same scheduled arrival and departure time arrays for many
@@ -278,13 +278,13 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
 
     /** @return the time in seconds after midnight that the vehicle arrives at the stop. */
     public int getArrivalTime(final int stop) {
-        if (arrivalTimes == null) { return getScheduledArrivalTime(stop); }
+        if (arrivalTimes == null || arrivalTimes[stop] == UNAVAILABLE) { return getScheduledArrivalTime(stop); }
         else return arrivalTimes[stop]; // updated times are not time shifted.
     }
 
     /** @return the amount of time in seconds that the vehicle waits at the stop. */
     public int getDepartureTime(final int stop) {
-        if (departureTimes == null) { return getScheduledDepartureTime(stop); }
+        if (departureTimes == null || departureTimes[stop] == UNAVAILABLE) { return getScheduledDepartureTime(stop); }
         else return departureTimes[stop]; // updated times are not time shifted.
     }
 

--- a/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/TripTimes.java
@@ -273,19 +273,7 @@ public class TripTimes implements Serializable, Comparable<TripTimes>, Cloneable
      * trip down the line.
      */
     public int sortIndex() {
-        if (realTimeState == RealTimeState.CANCELED) {
-            return -1;
-        }
-
-        int arrivalTime = getArrivalTime(0);
-        if (arrivalTime >= 0) {
-            return arrivalTime;
-        }
-        int departureTime = getDepartureTime(0);
-        if (departureTime >= 0) {
-            return departureTime;
-        }
-        throw new IllegalStateException("Failed to sort trip, initial (stop = 0) arrival and departure is -1");
+        return getArrivalTime(0);
     }
 
     /** @return the time in seconds after midnight that the vehicle arrives at the stop. */

--- a/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TimetableSnapshotSource.java
@@ -234,7 +234,8 @@ public class TimetableSnapshotSource implements TimetableSnapshotProvider {
                         applied = handleCanceledTrip(tripUpdate, feedId, serviceDate);
                         break;
                     case MODIFIED:
-                        applied = validateAndHandleModifiedTrip(graph, tripUpdate, feedId, serviceDate);
+                        LOG.info("Skipped MODIFIED TripUpdate for {}", new FeedScopedId(feedId, tripDescriptor.getTripId()));
+                        applied = false;
                         break;
                 }
 

--- a/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
+++ b/src/test/java/org/opentripplanner/routing/trippattern/TripTimesTest.java
@@ -70,7 +70,7 @@ public class TripTimesTest {
 
         updatedTripTimesA.updateDepartureTime(0, TripTimes.UNAVAILABLE);
 
-        assertEquals(TripTimes.UNAVAILABLE, updatedTripTimesA.getDepartureTime(0));
+        assertEquals(0, updatedTripTimesA.getDepartureTime(0));
         assertEquals(60, updatedTripTimesA.getArrivalTime(1));
     }
 
@@ -111,8 +111,8 @@ public class TripTimesTest {
                     updatedTripTimesA.getScheduledDepartureTime(i));
             assertEquals(originalTripTimes.getArrivalTime(i),
                     updatedTripTimesA.getScheduledArrivalTime(i));
-            assertEquals(TripTimes.UNAVAILABLE, updatedTripTimesA.getDepartureTime(i));
-            assertEquals(TripTimes.UNAVAILABLE, updatedTripTimesA.getArrivalTime(i));
+            assertEquals(i * 60, updatedTripTimesA.getDepartureTime(i));
+            assertEquals(i * 60, updatedTripTimesA.getArrivalTime(i));
         }
     }
 


### PR DESCRIPTION
Two main cases of problematic GTFS-rt updates are handled:
 1. if the `TripUpdate` modified the list of stops, which mainly means `SKIPPED` stop updates -- in these cases the replacement `Trip` may have invalid `StopTime`s => Modifying trips is disabled.
 1. if realtime data was `UNAVAILABLE` for a stop, a `-1` constant was used which caused problems in other parts. This is mitigated by:
    1. returning the scheduled arrival / departure time in theses cases
    2. adding an explicit check that the new / updated trip times are increasing
   
    If either of these checks fail, then the trip update is ignored.