### PR TITLE
Per-mode reluctance along with bike-walking and leg fixes

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLQueryTypeImpl.java
@@ -695,11 +695,15 @@ public class LegacyGraphQLQueryTypeImpl
       // callWith.argument("maxSlope", request::setMaxSlope);
       // callWith.argument("carParkCarLegWeight", request::setCarParkCarLegWeight);
       // callWith.argument("itineraryFiltering", request::setItineraryFiltering);
+      callWith.argument("bikeReluctance", request::setBikeReluctance);
+      callWith.argument("bikeWalkingReluctance", request::setBikeWalkingReluctance);
+      callWith.argument("carReluctance", request::setCarReluctance);
       callWith.argument("walkReluctance", request::setWalkReluctance);
       // callWith.argument("walkOnStreetReluctance", request::setWalkOnStreetReluctance);
       callWith.argument("waitReluctance", request::setWaitReluctance);
       callWith.argument("waitAtBeginningFactor", request::setWaitAtBeginningFactor);
       callWith.argument("walkSpeed", (Double v) -> request.walkSpeed = v);
+      callWith.argument("bikeWalkingSpeed", (Double v) -> request.bikeWalkingSpeed = v);
       callWith.argument("bikeSpeed", (Double v) -> request.bikeSpeed = v);
       callWith.argument("bikeSwitchTime", (Integer v) -> request.bikeSwitchTime = v);
       callWith.argument("bikeSwitchCost", (Integer v) -> request.bikeSwitchCost = v);

--- a/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
+++ b/src/ext/java/org/opentripplanner/ext/transmodelapi/TransmodelGraphQLPlanner.java
@@ -112,7 +112,7 @@ public class TransmodelGraphQLPlanner {
 //        callWith.argument("preTransitReluctance", (Double v) ->  request.setPreTransitReluctance(v));
 //        callWith.argument("maxPreTransitWalkDistance", (Double v) ->  request.setMaxPreTransitWalkDistance(v));
         callWith.argument("walkBoardCost", request::setWalkBoardCost);
-        callWith.argument("walkReluctance", request::setWalkReluctance);
+        callWith.argument("walkReluctance", request::setNonTransitReluctance);
         callWith.argument("waitReluctance", request::setWaitReluctance);
         callWith.argument("walkBoardCost", request::setWalkBoardCost);
 //        callWith.argument("walkOnStreetReluctance", request::setWalkOnStreetReluctance);

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -1745,6 +1745,24 @@ type QueryType {
         itineraryFiltering: Float
 
         """
+        A multiplier for how bad biking is, compared to being in transit for equal
+        lengths of time. Default value: 2.0
+        """
+        bikeReluctance: Float
+
+        """
+        A multiplier for how bad walking with a bike is, compared to being in transit for equal
+        lengths of time. Default value: 5.0
+        """
+        bikeWalkingReluctance: Float
+
+        """
+        A multiplier for how bad driving is, compared to being in transit for equal
+        lengths of time. Default value: 3.0
+        """
+        carReluctance: Float
+
+        """
         A multiplier for how bad walking is, compared to being in transit for equal
         lengths of time.Empirically, values between 10 and 20 seem to correspond
         well to the concept of not wanting to walk too much without asking for

--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -163,6 +163,13 @@ public abstract class RoutingResource {
     protected Integer maxPreTransitTime;
 
     /**
+     * A multiplier for how bad walking with a bike is, compared to being in transit for equal
+     * lengths of time. Defaults to 3.
+     */
+    @QueryParam("bikeWalkingReluctance")
+    protected Double bikeWalkingReluctance;
+
+    /**
      * A multiplier for how bad walking is, compared to being in transit for equal lengths of time.
      * Defaults to 2. Empirically, values between 10 and 20 seem to correspond well to the concept
      * of not wanting to walk too much without asking for totally ridiculous itineraries, but this
@@ -170,6 +177,12 @@ public abstract class RoutingResource {
      */
     @QueryParam("walkReluctance")
     protected Double walkReluctance;
+
+    @QueryParam("bikeReluctance")
+    protected Double bikeReluctance;
+
+    @QueryParam("carReluctance")
+    protected Double carReluctance;
 
     /**
      * How much worse is waiting for a transit vehicle than being on a transit vehicle, as a
@@ -198,6 +211,10 @@ public abstract class RoutingResource {
     /** The user's biking speed in meters/second. Defaults to approximately 11 MPH, or 9.5 for bikeshare. */
     @QueryParam("bikeSpeed")
     protected Double bikeSpeed;
+
+    /** The user's bike walking speed in meters/second. Defaults to approximately 3 MPH. */
+    @QueryParam("bikeWalkingSpeed")
+    protected Double bikeWalkingSpeed;
 
     /** The time it takes the user to fetch their bike and park it again in seconds.
      *  Defaults to 0. */
@@ -683,6 +700,15 @@ public abstract class RoutingResource {
         if (numItineraries != null)
             request.setNumItineraries(numItineraries);
 
+        if (bikeReluctance != null)
+            request.setBikeReluctance(bikeReluctance);
+
+        if (bikeWalkingReluctance != null)
+            request.setBikeWalkingReluctance(bikeWalkingReluctance);
+
+        if (carReluctance != null)
+            request.setCarReluctance(carReluctance);
+
         if (walkReluctance != null)
             request.setWalkReluctance(walkReluctance);
 
@@ -697,6 +723,9 @@ public abstract class RoutingResource {
 
         if (bikeSpeed != null)
             request.bikeSpeed = bikeSpeed;
+
+        if (bikeWalkingSpeed != null)
+            request.bikeWalkingSpeed = bikeWalkingSpeed;
 
         if (bikeSwitchTime != null)
             request.bikeSwitchTime = bikeSwitchTime;

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/GraphPathToItineraryMapper.java
@@ -215,6 +215,12 @@ public abstract class GraphPathToItineraryMapper {
                 legsIndexes.add(legIndexPairs);
                 legIndexPairs = new int[] {i, states.length - 1};
             }
+
+            if (rentalChange || parkingChange) {
+                /* Clear the lastMode, so that switching modes doesn't re-trigger a mode change
+                 * a few state's latter. */
+                lastMode = null;
+            }
         }
 
         // Final leg

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -381,6 +381,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      */
     public int carDropoffTime = 120;
 
+    /** Time of getting in/out of a carPickup (taxi) */
+    public int carPickupTime = 60;
+
+    /** Cost of getting in/out of a carPickup (taxi) */
+    public int carPickupCost = 120;
+
     /**
      * How much worse is waiting for a transit vehicle than being on a transit vehicle, as a multiplier. The default value treats wait and on-vehicle
      * time as the same.

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -243,6 +243,8 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public double bikeSpeed;
 
+    public double bikeWalkingSpeed;
+
     public double carSpeed;
 
     public Locale locale = new Locale("en", "US");
@@ -295,6 +297,12 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
      *  observation should in no way be taken as scientific or definitive. Your mileage may vary.
      */
     public double walkReluctance = 2.0;
+
+    public double bikeWalkingReluctance = 5.0;
+
+    public double bikeReluctance = 2.0;
+
+    public double carReluctance = 2.0;
 
     /** Used instead of walk reluctance for stairs */
     public double stairsReluctance = 2.0;
@@ -576,9 +584,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     /** For the bike triangle, how important safety is */
     public double bikeTriangleSafetyFactor;
 
-    /** Options specifically for the case that you are walking a bicycle. */
-    public RoutingRequest bikeWalkingOptions;
-
     /**
      * Whether or not bike rental availability information will be used to plan bike rental trips
      */
@@ -666,8 +671,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     @Deprecated
     public FeedScopedId startingTransitTripId;
 
-    public boolean walkingBike;
-
     /*
       Additional flags affecting mode transitions.
       This is a temporary solution, as it only covers parking and rental at the beginning of the trip.
@@ -737,10 +740,10 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         // http://en.wikipedia.org/wiki/Walking
         walkSpeed = 1.33; // 1.33 m/s ~ 3mph, avg. human speed
         bikeSpeed = 5; // 5 m/s, ~11 mph, a random bicycling speed
+        bikeWalkingSpeed = 1.33; // 1.33 m/s ~ 3mph, avg. human speed
         // http://en.wikipedia.org/wiki/Speed_limit
         carSpeed = 40; // 40 m/s, 144 km/h, above the maximum (finite) driving speed limit worldwide
         // Default to walk for access/egress/direct modes and all transit modes
-        bikeWalkingOptions = this;
 
         // So that they are never null.
         from = new GenericLocation(null, null);
@@ -779,7 +782,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setArriveBy(boolean arriveBy) {
         this.arriveBy = arriveBy;
-        bikeWalkingOptions.arriveBy = arriveBy;
     }
 
     public void setMode(TraverseMode mode) {
@@ -788,33 +790,10 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setStreetSubRequestModes(TraverseModeSet streetSubRequestModes) {
         this.streetSubRequestModes = streetSubRequestModes;
-        if (streetSubRequestModes.getBicycle()) {
-            // This alternate routing request is used when we get off a bike to take a shortcut and are
-            // walking alongside the bike. FIXME why are we only copying certain fields instead of cloning the request?
-            bikeWalkingOptions = new RoutingRequest();
-            bikeWalkingOptions.setArriveBy(this.arriveBy);
-            bikeWalkingOptions.walkSpeed = walkSpeed * 0.8; // walking bikes is slow
-            bikeWalkingOptions.walkReluctance = walkReluctance * 2.7; // and painful
-            bikeWalkingOptions.optimize = optimize;
-            bikeWalkingOptions.streetSubRequestModes = streetSubRequestModes.clone();
-            bikeWalkingOptions.streetSubRequestModes.setBicycle(false);
-            bikeWalkingOptions.streetSubRequestModes.setWalk(true);
-            bikeWalkingOptions.walkingBike = true;
-            bikeWalkingOptions.bikeSwitchTime = bikeSwitchTime;
-            bikeWalkingOptions.bikeSwitchCost = bikeSwitchCost;
-            bikeWalkingOptions.stairsReluctance = stairsReluctance * 5; // carrying bikes on stairs is awful
-        } else if (streetSubRequestModes.getCar()) {
-            bikeWalkingOptions = new RoutingRequest();
-            bikeWalkingOptions.setArriveBy(this.arriveBy);
-            bikeWalkingOptions.streetSubRequestModes = streetSubRequestModes.clone();
-            bikeWalkingOptions.streetSubRequestModes.setBicycle(false);
-            bikeWalkingOptions.streetSubRequestModes.setWalk(true);
-        }
     }
 
     public void setOptimize(BicycleOptimizeType optimize) {
         this.optimize = optimize;
-        bikeWalkingOptions.optimize = optimize;
     }
 
     public void setWheelchairAccessible(boolean wheelchairAccessible) {
@@ -1043,17 +1022,14 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
     public void setBikeTriangleSafetyFactor(double bikeTriangleSafetyFactor) {
         this.bikeTriangleSafetyFactor = bikeTriangleSafetyFactor;
-        bikeWalkingOptions.bikeTriangleSafetyFactor = bikeTriangleSafetyFactor;
     }
 
     public void setBikeTriangleSlopeFactor(double bikeTriangleSlopeFactor) {
         this.bikeTriangleSlopeFactor = bikeTriangleSlopeFactor;
-        bikeWalkingOptions.bikeTriangleSlopeFactor = bikeTriangleSlopeFactor;
     }
 
     public void setBikeTriangleTimeFactor(double bikeTriangleTimeFactor) {
         this.bikeTriangleTimeFactor = bikeTriangleTimeFactor;
-        bikeWalkingOptions.bikeTriangleTimeFactor = bikeTriangleTimeFactor;
     }
 
 
@@ -1067,37 +1043,32 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
             switch (streetMode) {
                 case WALK:
                 case FLEXIBLE:
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.WALK));
                     break;
                 case BIKE:
-                    streetRequest.streetSubRequestModes.setBicycle(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.BICYCLE));
                     break;
                 case BIKE_TO_PARK:
-                    streetRequest.streetSubRequestModes.setBicycle(true);
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.BICYCLE, TraverseMode.WALK));
                     streetRequest.parkAndRide = true;
                     break;
                 case BIKE_RENTAL:
-                    streetRequest.streetSubRequestModes.setBicycle(true);
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.BICYCLE, TraverseMode.WALK));
                     streetRequest.bikeRental = true;
                     break;
                 case CAR:
-                    streetRequest.streetSubRequestModes.setCar(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.CAR));
                     break;
                 case CAR_TO_PARK:
-                    streetRequest.streetSubRequestModes.setCar(true);
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.CAR, TraverseMode.WALK));
                     streetRequest.parkAndRide = true;
                     break;
                 case CAR_PICKUP:
-                    streetRequest.streetSubRequestModes.setCar(true);
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.CAR, TraverseMode.WALK));
                     streetRequest.carPickup = true;
                     break;
                 case CAR_RENTAL:
-                    streetRequest.streetSubRequestModes.setCar(true);
-                    streetRequest.streetSubRequestModes.setWalk(true);
+                    streetRequest.setStreetSubRequestModes(new TraverseModeSet(TraverseMode.CAR, TraverseMode.WALK));
             }
         }
 
@@ -1140,12 +1111,6 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
 
             clone.bannedTrips = (HashMap<FeedScopedId, BannedStopSet>) bannedTrips.clone();
 
-            if (this.bikeWalkingOptions != this) {
-                clone.bikeWalkingOptions = this.bikeWalkingOptions.clone();
-            }
-            else {
-                clone.bikeWalkingOptions = clone;
-            }
             return clone;
         } catch (CloneNotSupportedException e) {
             /* this will never happen since our super is the cloneable object */
@@ -1238,21 +1203,35 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     }
 
     /**
-     * @param mode
-     * @return The road speed for a specific traverse mode.
+     * The road speed for a specific traverse mode.
      */
-    public double getSpeed(TraverseMode mode) {
+    public double getReluctance(TraverseMode mode, boolean walkingBike) {
+        switch (mode) {
+            case WALK:
+                return walkingBike ? bikeWalkingReluctance : walkReluctance;
+            case BICYCLE:
+                return bikeReluctance;
+            case CAR:
+                return carReluctance;
+            default:
+                throw new IllegalArgumentException("getReluctance(): Invalid mode " + mode);
+        }
+    }
+
+    /**
+     * The road speed for a specific traverse mode.
+     */
+    public double getSpeed(TraverseMode mode, boolean walkingBike) {
         switch (mode) {
         case WALK:
-            return walkSpeed;
+            return walkingBike ? bikeWalkingSpeed : walkSpeed;
         case BICYCLE:
             return bikeSpeed;
         case CAR:
             return carSpeed;
         default:
-            break;
+            throw new IllegalArgumentException("getSpeed(): Invalid mode " + mode);
         }
-        throw new IllegalArgumentException("getSpeed(): Invalid mode " + mode);
     }
 
     /** @return The highest speed for all possible road-modes. */
@@ -1267,10 +1246,36 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
         return walkSpeed;
     }
 
+    public void setBikeReluctance(double bikeReluctance) {
+        if (bikeReluctance > 0) {
+            this.bikeReluctance = bikeReluctance;
+        }
+    }
+
+    public void setBikeWalkingReluctance(double bikeWalkingReluctance) {
+        if (bikeWalkingReluctance > 0) {
+            this.bikeWalkingReluctance = bikeWalkingReluctance;
+        }
+    }
+
+    public void setCarReluctance(double carReluctance) {
+        if (carReluctance > 0) {
+            this.carReluctance = carReluctance;
+        }
+    }
+
     public void setWalkReluctance(double walkReluctance) {
         if (walkReluctance > 0) {
             this.walkReluctance = walkReluctance;
-            // Do not set bikeWalkingOptions.walkReluctance here, because that needs a higher value.
+        }
+    }
+
+    public void setNonTransitReluctance(double nonTransitReluctance) {
+        if (nonTransitReluctance > 0) {
+            this.bikeReluctance = nonTransitReluctance;
+            this.walkReluctance = nonTransitReluctance;
+            this.carReluctance = nonTransitReluctance;
+            this.bikeWalkingReluctance = nonTransitReluctance * 2.7;
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/core/State.java
+++ b/src/main/java/org/opentripplanner/routing/core/State.java
@@ -55,7 +55,7 @@ public class State implements Cloneable {
     public static Collection<State> getInitialStates(RoutingRequest request) {
         Collection<State> states = new ArrayList<>();
         for (Vertex vertex : request.rctx.fromVertices) {
-            /* carPickup searches may end in two states (see isFinal()): IN_CAR and WALK_FROM_DROP_OFF/WALK_TO_PICKUP
+            /* carPickup searches may end in two distinct states: IN_CAR and WALK_FROM_DROP_OFF/WALK_TO_PICKUP
                for forward/reverse searches to be symmetric both initial states need to be created. */
             if (request.carPickup) {
                 states.add(
@@ -328,19 +328,14 @@ public class State implements Cloneable {
         boolean parkAndRide = stateData.opt.parkAndRide;
         boolean bikeRentingOk;
         boolean vehicleParkAndRideOk;
-        boolean pickedUpByCar;
         if (stateData.opt.arriveBy) {
             bikeRentingOk = !stateData.opt.bikeRental || !isBikeRenting();
             vehicleParkAndRideOk = !parkAndRide || !isVehicleParked();
-            // Checks that taxi has actually been used
-            pickedUpByCar = getCarPickupState() != CarPickupState.WALK_FROM_DROP_OFF;
         } else {
             bikeRentingOk = !stateData.opt.bikeRental || (bikeRentalNotStarted() || bikeRentalIsFinished());
             vehicleParkAndRideOk = !parkAndRide || isVehicleParked();
-            // Checks that taxi has actually been used
-            pickedUpByCar = getCarPickupState() != CarPickupState.WALK_TO_PICKUP;
         }
-        return bikeRentingOk && vehicleParkAndRideOk && pickedUpByCar;
+        return bikeRentingOk && vehicleParkAndRideOk;
     }
 
     public double getWalkDistance() {

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -271,6 +271,7 @@ public class StateEditor {
             child.stateData.bikeRentalState = BikeRentalState.HAVE_RENTED;
             child.stateData.currentMode = TraverseMode.WALK;
             child.stateData.bikeRentalNetworks = null;
+            child.stateData.backWalkingBike = false;
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/core/StateEditor.java
+++ b/src/main/java/org/opentripplanner/routing/core/StateEditor.java
@@ -304,6 +304,7 @@ public class StateEditor {
         cloneStateDataAsNeeded();
         child.stateData.carPickupState = state.stateData.carPickupState;
         child.stateData.vehicleParked = state.stateData.vehicleParked;
+        child.stateData.backWalkingBike = state.stateData.backWalkingBike;
     }
 
     public void setNonTransitOptionsFromState(State state) {

--- a/src/main/java/org/opentripplanner/routing/core/TraversalRequirements.java
+++ b/src/main/java/org/opentripplanner/routing/core/TraversalRequirements.java
@@ -16,11 +16,6 @@ public class TraversalRequirements {
     public TraverseModeSet modes = TraverseModeSet.allModes();
 
     /**
-     * The maximum distance (meters) the user is willing to walk. Defaults to 1/2 mile.
-     */
-    private double maxWalkDistance = 800;
-
-    /**
      * If true, trip must be wheelchair accessible.
      */
     private boolean wheelchairAccessible = false;
@@ -31,11 +26,6 @@ public class TraversalRequirements {
      * ADA max wheelchair ramp slope is a good default.
      */
     private double maxWheelchairSlope = 0.0833333333333;
-
-    /**
-     * Specific requirements for walking a bicycle.
-     */
-    private TraversalRequirements bikeWalkingRequirements;
 
     /**
      * Default constructor.
@@ -59,13 +49,6 @@ public class TraversalRequirements {
 
         // Initialize self.
         initFromRoutingRequest(this, options);
-
-        // Initialize walking requirements if any given.
-        RoutingRequest bikeWalkOptions = options.bikeWalkingOptions;
-        if (bikeWalkOptions != null) {
-            bikeWalkingRequirements = new TraversalRequirements();
-            initFromRoutingRequest(bikeWalkingRequirements, bikeWalkOptions);
-        }
     }
 
     /**
@@ -78,15 +61,6 @@ public class TraversalRequirements {
         req.modes = options.streetSubRequestModes.clone();
         req.wheelchairAccessible = options.wheelchairAccessible;
         req.maxWheelchairSlope = options.maxWheelchairSlope;
-    }
-
-    /**
-     * Returns true if bike walking requirements are defined.
-     * 
-     * @return
-     */
-    public boolean hasBikeWalkingRequirements() {
-        return bikeWalkingRequirements != null;
     }
 
     /** Returns true if this StreetEdge can be traversed. */
@@ -108,9 +82,6 @@ public class TraversalRequirements {
      */
     public boolean canBeTraversed(StreetEdge e) {
         if (canBeTraversedInternal(e)) {
-            return true;
-        } else if (hasBikeWalkingRequirements()
-                && bikeWalkingRequirements.canBeTraversedInternal(e)) {
             return true;
         }
         return false;

--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeWalkableEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeWalkableEdge.java
@@ -8,7 +8,15 @@ import org.opentripplanner.routing.graph.Edge;
 
 public interface BikeWalkableEdge {
 
-    default void switchToWalkingBike(RoutingRequest options, StateEditor editor, boolean includeCostAndTime) {
+    default boolean canSwitchToWalkingBike(State state) {
+        return state.getNonTransitMode() == TraverseMode.BICYCLE;
+    }
+
+    default void switchToWalkingBike(
+            RoutingRequest options,
+            StateEditor editor,
+            boolean includeCostAndTime
+    ) {
         editor.setBackWalkingBike(true);
         if (includeCostAndTime) {
             editor.incrementWeight(options.bikeSwitchCost);
@@ -20,5 +28,41 @@ public interface BikeWalkableEdge {
         editor.setBackWalkingBike(false);
         editor.incrementWeight(options.bikeSwitchCost);
         editor.incrementTimeInSeconds(options.bikeSwitchTime);
+    }
+
+    default StateEditor createEditorForWalking(State state, Edge edge) {
+        StateEditor editor = state.edit(edge);
+
+        if (state.getNonTransitMode() == TraverseMode.CAR) {
+            return null;
+        }
+        else if (state.getNonTransitMode() == TraverseMode.BICYCLE) {
+            if (canSwitchToWalkingBike(state)) {
+                // If this is the first traversed edge than the bikeSwitch cost doesn't need to be applied
+                var shouldIncludeCost = !state.isBackWalkingBike() && hadBackModeSet(state);
+                switchToWalkingBike(state.getOptions(), editor, shouldIncludeCost);
+            }
+            else {
+                return null;
+            }
+        }
+        else if (state.getNonTransitMode() != TraverseMode.WALK) {
+            return null;
+        }
+
+        editor.setBackMode(TraverseMode.WALK);
+
+        return editor;
+    }
+
+    default boolean hadBackModeSet(State state) {
+        do {
+            if (state.getBackMode() != null) {
+                return true;
+            }
+            state = state.getBackState();
+        } while (state != null);
+
+        return false;
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeWalkableEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeWalkableEdge.java
@@ -1,0 +1,24 @@
+package org.opentripplanner.routing.edgetype;
+
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Edge;
+
+public interface BikeWalkableEdge {
+
+    default void switchToWalkingBike(RoutingRequest options, StateEditor editor, boolean includeCostAndTime) {
+        editor.setBackWalkingBike(true);
+        if (includeCostAndTime) {
+            editor.incrementWeight(options.bikeSwitchCost);
+            editor.incrementTimeInSeconds(options.bikeSwitchTime);
+        }
+    }
+
+    default void switchToBiking(RoutingRequest options, StateEditor editor) {
+        editor.setBackWalkingBike(false);
+        editor.incrementWeight(options.bikeSwitchCost);
+        editor.incrementTimeInSeconds(options.bikeSwitchTime);
+    }
+}

--- a/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/CarPickupableEdge.java
@@ -24,9 +24,13 @@ public interface CarPickupableEdge {
         editor.setCarPickupState(state.getOptions().arriveBy
                 ? CarPickupState.WALK_TO_PICKUP
                 : CarPickupState.WALK_FROM_DROP_OFF);
+        editor.incrementTimeInSeconds(state.getOptions().carPickupTime);
+        editor.incrementWeight(state.getOptions().carPickupCost);
     }
 
     default void driveAfterPickup(State state, StateEditor editor) {
         editor.setCarPickupState(CarPickupState.IN_CAR);
+        editor.incrementTimeInSeconds(state.getOptions().carPickupTime);
+        editor.incrementWeight(state.getOptions().carPickupCost);
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorAlightEdge.java
@@ -1,16 +1,14 @@
 package org.opentripplanner.routing.edgetype;
 
+import java.util.Locale;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.vertextype.ElevatorOffboardVertex;
 import org.opentripplanner.routing.vertextype.ElevatorOnboardVertex;
-
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
 
 /**
  * A relatively low cost edge for alighting from an elevator.
@@ -19,7 +17,7 @@ import java.util.Locale;
  * @author mattwigway
  *
  */
-public class ElevatorAlightEdge extends Edge implements ElevatorEdge {
+public class ElevatorAlightEdge extends Edge implements BikeWalkableEdge, ElevatorEdge {
 
     private static final long serialVersionUID = 3925814840369402222L;
 
@@ -51,9 +49,8 @@ public class ElevatorAlightEdge extends Edge implements ElevatorEdge {
     
     @Override
     public State traverse(State s0) {
-        StateEditor s1 = s0.edit(this);
+        StateEditor s1 = createElevatorStateEditor(s0, this);
         s1.incrementWeight(1);
-        s1.setBackMode(TraverseMode.WALK);
         return s1.makeState();
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorBoardEdge.java
@@ -1,16 +1,16 @@
 package org.opentripplanner.routing.edgetype;
 
-import org.opentripplanner.common.geometry.GeometryUtils;
-import org.opentripplanner.routing.core.State;
-import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.api.request.RoutingRequest;
-import org.opentripplanner.routing.core.TraverseMode;
-import org.opentripplanner.routing.graph.Edge;
-import org.opentripplanner.routing.graph.Vertex;
-
+import java.util.Locale;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
-import java.util.Locale;
+import org.opentripplanner.common.geometry.GeometryUtils;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.vertextype.ElevatorOffboardVertex;
+import org.opentripplanner.routing.vertextype.ElevatorOnboardVertex;
 
 
 /**
@@ -18,7 +18,7 @@ import java.util.Locale;
  * @author mattwigway
  *
  */
-public class ElevatorBoardEdge extends Edge implements ElevatorEdge {
+public class ElevatorBoardEdge extends Edge implements BikeWalkableEdge, ElevatorEdge {
 
     private static final long serialVersionUID = 3925814840369402222L;
 
@@ -29,7 +29,7 @@ public class ElevatorBoardEdge extends Edge implements ElevatorEdge {
      */
     private LineString the_geom;
 
-    public ElevatorBoardEdge(Vertex from, Vertex to) {
+    public ElevatorBoardEdge(ElevatorOffboardVertex from, ElevatorOnboardVertex to) {
         super(from, to);
 
         // set up the geometry
@@ -40,14 +40,13 @@ public class ElevatorBoardEdge extends Edge implements ElevatorEdge {
     }
     
     @Override
-    public State traverse(State s0) { 
-        RoutingRequest options = s0.getOptions();
+    public State traverse(State s0) {
+        StateEditor s1 = createElevatorStateEditor(s0, this);
 
-        StateEditor s1 = s0.edit(this);
-        // We always walk in elevators, even when we have a bike with us
-        s1.setBackMode(TraverseMode.WALK);
+        RoutingRequest options = s0.getOptions();
         s1.incrementWeight(options.elevatorBoardCost);
         s1.incrementTimeInSeconds(options.elevatorBoardTime);
+
         return s1.makeState();
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorEdge.java
@@ -1,9 +1,21 @@
 package org.opentripplanner.routing.edgetype;
 
+import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.core.StateEditor;
+import org.opentripplanner.routing.core.TraverseMode;
+import org.opentripplanner.routing.graph.Edge;
+
 /**
  * Marker interface indicating that an edge is part of an elevator.
  * 
  * @author mattwigway
  */
-public interface ElevatorEdge {
+public interface ElevatorEdge extends BikeWalkableEdge {
+
+    default StateEditor createElevatorStateEditor(State s0, Edge edge) {
+        if (s0.getNonTransitMode() == TraverseMode.CAR) {
+            return s0.edit(edge);
+        }
+        return createEditorForWalking(s0, edge);
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/ElevatorHopEdge.java
@@ -64,8 +64,7 @@ public class ElevatorHopEdge extends Edge implements ElevatorEdge {
             return null;
         }
 
-        StateEditor s1 = s0.edit(this);
-        s1.setBackMode(TraverseMode.WALK);
+        StateEditor s1 = createElevatorStateEditor(s0, this);
         s1.incrementWeight(
             this.travelTime > 0 ? this.travelTime : (options.elevatorHopCost * this.levels)
         );

--- a/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/FreeEdge.java
@@ -27,7 +27,7 @@ public class FreeEdge extends Edge {
     public State traverse(State s0) {
         StateEditor s1 = s0.edit(this);
         s1.incrementWeight(1);
-        // do not change mode, which means it may be null at the start of a trip
+        s1.setBackMode(null);
         return s1.makeState();
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -15,7 +15,7 @@ import java.util.Locale;
 /**
  * A walking pathway as described in GTFS
  */
-public class PathwayEdge extends Edge {
+public class PathwayEdge extends Edge implements BikeWalkableEdge {
 
     private static final long serialVersionUID = -3311099256178798982L;
 
@@ -80,10 +80,6 @@ public class PathwayEdge extends Edge {
         return traversalTime;
     }
 
-    public TraverseMode getMode() {
-       return TraverseMode.WALK;
-    }
-
     public LineString getGeometry() {
         Coordinate[] coordinates = new Coordinate[] { getFromVertex().getCoordinate(),
                 getToVertex().getCoordinate() };
@@ -107,6 +103,8 @@ public class PathwayEdge extends Edge {
     public FeedScopedId getId( ){ return id; }
 
     public State traverse(State s0) {
+        StateEditor s1 = createEditorForWalking(s0, this);
+
         /* TODO: Consider mode, so that passing through multiple fare gates is not possible */
         int time = traversalTime;
         if (s0.getOptions().wheelchairAccessible) {
@@ -117,6 +115,7 @@ public class PathwayEdge extends Edge {
                 return null;
             }
         }
+
         if (time == 0) {
             if (distance > 0) {
                 time = (int) (distance * s0.getOptions().walkSpeed);
@@ -126,10 +125,15 @@ public class PathwayEdge extends Edge {
                 time = (int) (0.4 * Math.abs(steps) * s0.getOptions().walkSpeed);
             }
         }
-        StateEditor s1 = s0.edit(this);
+
+        if (time <= 0) {
+            return null;
+        }
+
+        double weight = time * s0.getOptions().getReluctance(TraverseMode.WALK, s0.getNonTransitMode() == TraverseMode.BICYCLE);
+
         s1.incrementTimeInSeconds(time);
-        s1.incrementWeight(time);
-        s1.setBackMode(getMode());
+        s1.incrementWeight(weight);
         return s1.makeState();
     }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author novalis
  * 
  */
-public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
+public class StreetEdge extends Edge implements BikeWalkableEdge, Cloneable, CarPickupableEdge {
 
     private static Logger LOG = LoggerFactory.getLogger(StreetEdge.class);
 
@@ -250,11 +250,27 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
     @Override
     public State traverse(State s0) {
         final RoutingRequest options = s0.getOptions();
-        StateEditor editor = doTraverse(s0, options, s0.getNonTransitMode());
-        State state = (editor == null) ? null : editor.makeState();
+        final StateEditor editor;
+
+        // If we are biking, or walking with a bike check if we may continue by biking or by walking
+        if (s0.getNonTransitMode() == TraverseMode.BICYCLE) {
+            if (canTraverse(options, TraverseMode.BICYCLE)) {
+                editor = doTraverse(s0, options, TraverseMode.BICYCLE, false);
+            } else if (canTraverse(options, TraverseMode.WALK)) {
+                editor = doTraverse(s0, options, TraverseMode.WALK, true);
+            } else {
+                return null;
+            }
+        } else if (canTraverse(options, s0.getNonTransitMode())) {
+            editor = doTraverse(s0, options, s0.getNonTransitMode(), false);
+        } else {
+            editor = null;
+        }
+
+        State state = editor != null ? editor.makeState() : null;
 
         if (canPickupAndDrive(s0)) {
-            StateEditor inCar = doTraverse(s0, options, TraverseMode.CAR);
+            StateEditor inCar = doTraverse(s0, options, TraverseMode.CAR, false);
             if (inCar != null) {
                 driveAfterPickup(s0, inCar);
                 State forkState = inCar.makeState();
@@ -267,11 +283,11 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
         }
 
         if (canDropOffAfterDriving(s0) && !getPermission().allows(TraverseMode.CAR)) {
-            editor = doTraverse(s0, options, TraverseMode.WALK);
-            if (editor != null) {
-                dropOffAfterDriving(s0, editor);
+            StateEditor dropOff = doTraverse(s0, options, TraverseMode.WALK, false);
+            if (dropOff != null) {
+                dropOffAfterDriving(s0, dropOff);
                 // Only the walk state is returned, since traversing by car was not possible
-                return editor.makeState();
+                return dropOff.makeState();
             }
         }
 
@@ -279,9 +295,13 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
     }
 
     /** return a StateEditor rather than a State so that we can make parking/mode switch modifications for kiss-and-ride. */
-    private StateEditor doTraverse(State s0, RoutingRequest options, TraverseMode traverseMode) {
+    private StateEditor doTraverse(
+            State s0,
+            RoutingRequest options,
+            TraverseMode traverseMode,
+            boolean walkingBike
+    ) {
         if (traverseMode == null) { return null; }
-        boolean walkingBike = options.walkingBike;
         boolean backWalkingBike = s0.isBackWalkingBike();
         TraverseMode backMode = s0.getBackMode();
         Edge backEdge = s0.getBackEdge();
@@ -297,20 +317,13 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
             }
         }
 
-        // Ensure we are actually walking, when walking a bike
-        backWalkingBike &= TraverseMode.WALK.equals(backMode);
-        walkingBike &= TraverseMode.WALK.equals(traverseMode);
-
-        /* Check whether this street allows the current mode. If not and we are biking, attempt to walk the bike. */
+        /* Check whether this street allows the current mode. */
         if (!canTraverse(options, traverseMode)) {
-            if (traverseMode == TraverseMode.BICYCLE) {
-                return doTraverse(s0, options.bikeWalkingOptions, TraverseMode.WALK);
-            }
             return null;
         }
 
         // Automobiles have variable speeds depending on the edge type
-        double speed = calculateSpeed(options, traverseMode, s0.getTimeInMillis());
+        double speed = calculateSpeed(options, traverseMode, walkingBike);
         
         double time = getEffectiveWalkDistance() / speed;
         double weight;
@@ -377,11 +390,19 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
         if (isStairs()) {
             weight *= options.stairsReluctance;
         } else {
-            // TODO: this is being applied even when biking or driving.
-            weight *= options.walkReluctance;
+            weight *= options.getReluctance(traverseMode, walkingBike);
         }
 
         StateEditor s1 = s0.edit(this);
+        if (walkingBike != backWalkingBike) {
+            if (walkingBike) {
+                boolean hadPreviousBiking = backMode == TraverseMode.BICYCLE;
+                switchToWalkingBike(s0.getOptions(), s1, hadPreviousBiking);
+            } else {
+                switchToBiking(s0.getOptions(), s1);
+            }
+        }
+
         s1.setBackMode(traverseMode);
         s1.setBackWalkingBike(walkingBike);
 
@@ -393,9 +414,8 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
         StreetEdge backPSE;
         if (backEdge instanceof StreetEdge) {
             backPSE = (StreetEdge) backEdge;
-            RoutingRequest backOptions = backWalkingBike ?
-                    s0.getOptions().bikeWalkingOptions : s0.getOptions();
-            double backSpeed = backPSE.calculateSpeed(backOptions, backMode, s0.getTimeInMillis());
+            RoutingRequest backOptions = s0.getOptions();
+            double backSpeed = backPSE.calculateSpeed(backOptions, backMode, backWalkingBike);
             final double realTurnCost;  // Units are seconds.
 
             // Apply turn restrictions
@@ -441,13 +461,6 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
             int turnTime = (int) Math.ceil(realTurnCost);
             roundedTime += turnTime;
             weight += options.turnReluctance * realTurnCost;
-        }
-
-        if (walkingBike || TraverseMode.BICYCLE.equals(traverseMode)) {
-            if (!(backWalkingBike || TraverseMode.BICYCLE.equals(backMode))) {
-                s1.incrementTimeInSeconds(options.bikeSwitchTime);
-                s1.incrementWeight(options.bikeSwitchCost);
-            }
         }
 
         if (!traverseMode.isDriving()) {
@@ -502,19 +515,20 @@ public class StreetEdge extends Edge implements Cloneable, CarPickupableEdge {
     }
     
     /**
-     * Calculate the speed appropriately given the RoutingRequest and traverseMode and the current wall clock time.
-     * Note: this is not strictly symmetrical, because in a forward search we get the speed based on the
-     * time we enter this edge, whereas in a reverse search we get the speed based on the time we exit
-     * the edge.
+     * Calculate the speed appropriately given the RoutingRequest and traverseMode.
      */
-    public double calculateSpeed(RoutingRequest options, TraverseMode traverseMode, long timeMillis) {
+    public double calculateSpeed(
+            RoutingRequest options,
+            TraverseMode traverseMode,
+            boolean walkingBike
+    ) {
         if (traverseMode == null) {
             return Double.NaN;
         } else if (traverseMode.isDriving()) {
             // NOTE: Automobiles have variable speeds depending on the edge type
             return calculateCarSpeed(options);
         }
-        return options.getSpeed(traverseMode);
+        return options.getSpeed(traverseMode, walkingBike);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetTransitEntityLink.java
@@ -8,7 +8,6 @@ import org.opentripplanner.model.Trip;
 import org.opentripplanner.routing.api.request.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
-import org.opentripplanner.routing.core.TraverseMode;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Vertex;
 import org.opentripplanner.routing.vertextype.StreetVertex;
@@ -91,18 +90,29 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
             return null;
         }
 
-        // Do not check here whether any transit modes are selected. A check for the presence of
-        // transit modes will instead be done in the following PreBoard edge.
-        // This allows searching for nearby transit stops using walk-only options.
         StateEditor s1 = s0.edit(this);
 
-        if (s0.getNonTransitMode() == TraverseMode.CAR) {
-            // For Kiss & Ride allow dropping of the passenger before entering the station
-            if (canDropOffAfterDriving(s0) && isLeavingStreetNetwork(req)) {
-                dropOffAfterDriving(s0, s1);
-            } else if (s0.getCarPickupState() != null) {
+        switch (s0.getNonTransitMode()) {
+            case BICYCLE:
+                // Forbid taking a (station) rental bike in the station. This allows taking along
+                // floating bikes.
+                if (s0.isBikeRentingFromStation() && !(s0.mayKeepRentedBicycleAtDestination() && s0.getOptions().allowKeepingRentedBicycleAtDestination)) {
+                    return null;
+                }
+                // Allow taking an owned bike in the station
+                break;
+            case CAR:
+                // For Kiss & Ride allow dropping of the passenger before entering the station
+                if (canDropOffAfterDriving(s0) && isLeavingStreetNetwork(req)) {
+                    dropOffAfterDriving(s0, s1);
+                    break;
+                } else {
+                    return null;
+                }
+            case WALK:
+                break;
+            default:
                 return null;
-            }
         }
 
         if (s0.isBikeRentingFromStation()
@@ -113,7 +123,7 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
 
         s1.setBackMode(null);
 
-        // We do not increase the time here, so that searching from the stop coordinates instead of
+        // streetToStopTime may be zero so that searching from the stop coordinates instead of
         // the stop id catch transit departing at that exact search time.
         int streetToStopTime = getStreetToStopTime();
         s1.incrementTimeInSeconds(streetToStopTime);
@@ -144,6 +154,4 @@ public abstract class StreetTransitEntityLink<T extends Vertex> extends Edge imp
     public String toString() {
         return "StreetTransitLink(" + fromv + " -> " + tov + ")";
     }
-
-
 }

--- a/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
+++ b/src/main/java/org/opentripplanner/routing/spt/SPTWalker.java
@@ -100,7 +100,7 @@ public class SPTWalker {
                          * walk...) and edge properties (car max speed, slope, etc...)
                          */
                         TraverseMode mode = s0.getNonTransitMode();
-                        speedAlongEdge = se.calculateSpeed(spt.getOptions(), mode, s0.getTimeInMillis());
+                        speedAlongEdge = se.calculateSpeed(spt.getOptions(), mode, false);
                         if (mode != TraverseMode.CAR)
                             speedAlongEdge = speedAlongEdge * se.getDistanceMeters() / se.getEffectiveBikeDistance();
                         double avgSpeed = se.getDistanceMeters()

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -32,6 +32,7 @@ public class RoutingRequestMapper {
         request.bikeBoardCost = c.asInt("bikeBoardCost", dft.bikeBoardCost);
         request.bikeParkTime = c.asInt("bikeParkTime", dft.bikeParkTime);
         request.bikeParkCost = c.asInt("bikeParkCost", dft.bikeParkCost);
+        request.bikeReluctance = c.asDouble("bikeReluctance", dft.bikeReluctance);
         request.bikeRentalDropoffCost = c.asInt("bikeRentalDropoffCost", dft.bikeRentalDropoffCost);
         request.bikeRentalDropoffTime = c.asInt("bikeRentalDropoffTime", dft.bikeRentalDropoffTime);
         request.bikeRentalPickupCost = c.asInt("bikeRentalPickupCost", dft.bikeRentalPickupCost);
@@ -42,6 +43,8 @@ public class RoutingRequestMapper {
         request.bikeTriangleTimeFactor = c.asDouble("bikeTriangleTimeFactor", dft.bikeTriangleTimeFactor);
         request.bikeSwitchTime = c.asInt("bikeSwitchTime", dft.bikeSwitchTime);
         request.bikeSwitchCost = c.asInt("bikeSwitchCost", dft.bikeSwitchCost);
+        request.bikeWalkingReluctance = c.asDouble("bikeWalkingReluctance", dft.bikeWalkingReluctance);
+        request.bikeWalkingSpeed = c.asDouble("bikeWalkingSpeed", dft.bikeWalkingSpeed);
         request.allowKeepingRentedBicycleAtDestination = c.asBoolean("allowKeepingRentedBicycleAtDestination", dft.allowKeepingRentedBicycleAtDestination);
         request.keepingRentedBicycleAtDestinationCost = c.asDouble("keepingRentedBicycleAtDestinationCost", dft.keepingRentedBicycleAtDestinationCost);
         request.boardSlack = c.asInt("boardSlack", dft.boardSlack);
@@ -53,6 +56,7 @@ public class RoutingRequestMapper {
         request.carParkTime = c.asInt("carParkTime", dft.carParkTime);
         request.carPickupCost = c.asInt("carPickupCost", dft.carPickupCost);
         request.carPickupTime = c.asInt("carPickupTime", dft.carPickupTime);
+        request.carReluctance = c.asDouble("carReluctance", dft.carReluctance);
         request.carSpeed = c.asDouble("carSpeed", dft.carSpeed);
         request.itineraryFilters = ItineraryFiltersMapper.map(c.path("itineraryFilters"));
         request.disableAlertFiltering = c.asBoolean("disableAlertFiltering", dft.disableAlertFiltering);
@@ -92,7 +96,6 @@ public class RoutingRequestMapper {
         request.walkBoardCost = c.asInt("walkBoardCost", dft.walkBoardCost);
         request.walkReluctance = c.asDouble("walkReluctance", dft.walkReluctance);
         request.walkSpeed = c.asDouble("walkSpeed", dft.walkSpeed);
-        request.walkingBike = c.asBoolean("walkingBike", dft.walkingBike);
         request.wheelchairAccessible = c.asBoolean("wheelchairAccessible", dft.wheelchairAccessible);
 
         mapTransferOptimization(

--- a/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
+++ b/src/main/java/org/opentripplanner/standalone/config/RoutingRequestMapper.java
@@ -49,8 +49,10 @@ public class RoutingRequestMapper {
         request.carAccelerationSpeed = c.asDouble("carAccelerationSpeed", dft.carAccelerationSpeed);
         request.carDecelerationSpeed = c.asDouble("carDecelerationSpeed", dft.carDecelerationSpeed);
         request.carDropoffTime = c.asInt("carDropoffTime", dft.carDropoffTime);
-        request.carParkTime = c.asInt("carParkTime", dft.carParkTime);
         request.carParkCost = c.asInt("carParkCost", dft.carParkCost);
+        request.carParkTime = c.asInt("carParkTime", dft.carParkTime);
+        request.carPickupCost = c.asInt("carPickupCost", dft.carPickupCost);
+        request.carPickupTime = c.asInt("carPickupTime", dft.carPickupTime);
         request.carSpeed = c.asDouble("carSpeed", dft.carSpeed);
         request.itineraryFilters = ItineraryFiltersMapper.map(c.path("itineraryFilters"));
         request.disableAlertFiltering = c.asBoolean("disableAlertFiltering", dft.disableAlertFiltering);

--- a/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/map/TestStreetMatcher.java
@@ -165,7 +165,7 @@ public class TestStreetMatcher {
         public State traverse(State s0) {
             double d = getDistanceMeters();
             TraverseMode mode = s0.getNonTransitMode();
-            int t = (int) (d / s0.getOptions().getSpeed(mode));
+            int t = (int) (d / s0.getOptions().getSpeed(mode, false));
             StateEditor s1 = s0.edit(this);
             s1.incrementTimeInSeconds(t);
             s1.incrementWeight(d);

--- a/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
+++ b/src/test/java/org/opentripplanner/graph_builder/module/osm/TriangleInequalityTest.java
@@ -87,7 +87,7 @@ public class TriangleInequalityTest {
         
         // All reluctance terms are 1.0 so that duration is monotonically increasing in weight.
         prototypeOptions.stairsReluctance = (1.0);
-        prototypeOptions.setWalkReluctance(1.0);
+        prototypeOptions.setNonTransitReluctance(1.0);
         prototypeOptions.turnReluctance = (1.0);
         prototypeOptions.carSpeed = 1.0;
         prototypeOptions.walkSpeed = 1.0;

--- a/src/test/java/org/opentripplanner/routing/algorithm/BicycleParkAndRideTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BicycleParkAndRideTest.java
@@ -70,11 +70,11 @@ public class BicycleParkAndRideTest extends ParkAndRideTest {
         assertPath(
                 B, D, StreetMode.BIKE_TO_PARK,
                 "null - null (0.00, 0)",
-                "WALK - BC street (130.83, 66)",
-                "null - BikePark Entrance (131.83, 66)",
-                "null (parked) - BikePark Entrance (251.83, 126)",
-                "null (parked) - BikePark Entrance (252.83, 126)",
-                "WALK (parked) - CD street (383.65, 192)"
+                "WALK - BC street (327.07, 66)",
+                "null - BikePark Entrance (328.07, 66)",
+                "null (parked) - BikePark Entrance (448.07, 126)",
+                "null (parked) - BikePark Entrance (449.07, 126)",
+                "WALK (parked) - CD street (579.89, 192)"
         );
     }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeRentalTest.java
@@ -96,7 +96,7 @@ public class BikeRentalTest extends GraphRoutingTest {
                 StreetMode.BIKE
         );
 
-        assertEquals(List.of("WALK - null - BC street (1,503.76, 752)"), descriptor);
+        assertEquals(List.of("WALK - null - BC street (3,759.40, 752)"), descriptor);
     }
 
     // This tests exists to test if the cost of biking changes

--- a/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/BikeWalkingTest.java
@@ -1,0 +1,377 @@
+package org.opentripplanner.routing.algorithm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.algorithm.astar.AStar;
+import org.opentripplanner.routing.api.request.RoutingRequest;
+import org.opentripplanner.routing.api.request.StreetMode;
+import org.opentripplanner.routing.edgetype.StreetEdge;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.vertextype.StreetVertex;
+import org.opentripplanner.routing.vertextype.TransitEntranceVertex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+
+/**
+ * Test switching between biking / walking over multiple edges.
+ * <p>
+ * arriveBy and departAt paths should be symmetric.
+ */
+public class BikeWalkingTest extends GraphRoutingTest {
+
+    private Graph graph;
+    private TransitStopVertex S1, S2;
+    private TransitEntranceVertex E1;
+    private StreetVertex A, B, C, D, E, F, Q;
+    private StreetEdge AB, BC, CD, DE, EF;
+
+    @BeforeEach
+    protected void setUp() throws Exception {
+        // Generate a very simple graph
+        //
+        //   TS1 <-> A <-> B <-> C <-> D <-> E <-> F <-> E1 <-> S2
+
+        graph = graphOf(new Builder() {
+            @Override
+            public void build() {
+                S1 = stop("S1", 0, 45);
+                S2 = stop("S2", 0.005, 45);
+                E1 = entrance("E1", 0.004, 45);
+                A = intersection("A", 0.001, 45);
+                B = intersection("B", 0.002, 45);
+                C = intersection("C", 0.003, 45);
+                D = intersection("D", 0.004, 45);
+                E = intersection("E", 0.005, 45);
+                F = intersection("F", 0.006, 45);
+                Q = intersection("Q", 0.009, 45);
+
+                elevator(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE, D, Q);
+
+                biLink(A, S1);
+                AB = street(A, B, 100, StreetTraversalPermission.PEDESTRIAN);
+                BC = street(B, C, 100, StreetTraversalPermission.PEDESTRIAN);
+                CD = street(C, D, 100, StreetTraversalPermission.ALL);
+                DE = street(D, E, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+                EF = street(E, F, 100, StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+                biLink(F, E1);
+                pathway(E1, S2, 60, 100);
+            }
+        });
+    }
+
+    @Test
+    public void testWalkOnly() {
+        assertWalkPath(
+                C, F,
+                "null - 0 / 0.0 - null",
+                "WALK - 10 / 20.0 - CD street",
+                "WALK - 10 / 20.0 - DE street",
+                "WALK - 10 / 20.0 - EF street"
+        );
+    }
+
+    // An initial cost should not be applied when biking all the way.
+    @Test
+    public void testBikeOnly() {
+        assertBikePath(
+                C, F,
+                "null - 0 / 0.0 - null",
+                "BICYCLE - 5 / 10.0 - CD street",
+                "BICYCLE - 5 / 10.0 - DE street",
+                "BICYCLE - 5 / 10.0 - EF street"
+        );
+    }
+
+    // An cost should be applied when both dismounting and mounting the bike.
+    @Test
+    public void testMiddleWalkBike() {
+        AB.setPermission(StreetTraversalPermission.BICYCLE);
+        BC.setPermission(StreetTraversalPermission.PEDESTRIAN);
+        CD.setPermission(StreetTraversalPermission.PEDESTRIAN);
+        DE.setPermission(StreetTraversalPermission.BICYCLE);
+
+        assertPath(
+                A, E, StreetMode.BIKE,
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 5 / 10.0 - AB street",
+                        "🚲WALK - 120 / 1100.0 - BC street",
+                        "🚲WALK - 20 / 100.0 - CD street",
+                        "BICYCLE - 105 / 1010.0 - DE street"
+                ),
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 105 / 1010.0 - AB street",
+                        "🚲WALK - 20 / 100.0 - BC street",
+                        "🚲WALK - 120 / 1100.0 - CD street",
+                        "BICYCLE - 5 / 10.0 - DE street"
+                )
+        );
+    }
+
+    // A cost should be applied when switching to walking only.
+    @Test
+    public void testEndingWalkBike() {
+        assertPath(
+                A, F, StreetMode.BIKE,
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "🚲WALK - 20 / 100.0 - AB street",
+                        "🚲WALK - 20 / 100.0 - BC street",
+                        "BICYCLE - 105 / 1010.0 - CD street",
+                        "BICYCLE - 5 / 10.0 - DE street",
+                        "BICYCLE - 5 / 10.0 - EF street"
+                ),
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "🚲WALK - 20 / 100.0 - AB street",
+                        "🚲WALK - 120 / 1100.0 - BC street",
+                        "BICYCLE - 5 / 10.0 - CD street",
+                        "BICYCLE - 5 / 10.0 - DE street",
+                        "BICYCLE - 5 / 10.0 - EF street"
+                )
+        );
+    }
+
+    // No cost should be applied, since no dismounting/mounting takes place.
+    @Test
+    public void testOnlyWalkBike() {
+        assertBikePath(
+                A, C,
+                "null - 0 / 0.0 - null",
+                "🚲WALK - 20 / 100.0 - AB street",
+                "🚲WALK - 20 / 100.0 - BC street"
+        );
+    }
+
+    // A cost should not be applied when entering / leaving since no mount / dismount takes place.
+    @Test
+    public void testEntranceStopLinkWalking() {
+        assertWalkPath(
+                S1, B,
+                "null - 0 / 0.0 - null",
+                "null - 0 / 1.0 - S1",
+                "WALK - 10 / 20.0 - AB street"
+        );
+
+        assertWalkPath(
+                E, E1,
+                "null - 0 / 0.0 - null",
+                "WALK - 10 / 20.0 - EF street",
+                "null - 0 / 1.0 - E1"
+        );
+    }
+
+    // A cost should not be applied when entering / leaving since no mount / dismount takes place.
+    @Test
+    public void testEntranceStopLinkBiking() {
+        AB.setPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE);
+
+        assertBikePath(
+                S1, B,
+                "null - 0 / 0.0 - null",
+                "null - 0 / 1.0 - S1",
+                "BICYCLE - 5 / 10.0 - AB street"
+        );
+
+        assertBikePath(
+                E, E1,
+                "null - 0 / 0.0 - null",
+                "BICYCLE - 5 / 10.0 - EF street",
+                "null - 0 / 1.0 - E1"
+        );
+    }
+
+    @Test
+    public void testEntranceStopLinkBikeWalking() {
+        EF.setPermission(StreetTraversalPermission.PEDESTRIAN);
+
+        assertBikePath(
+                S1, B,
+                "null - 0 / 0.0 - null",
+                "null - 0 / 1.0 - S1",
+                "🚲WALK - 20 / 100.0 - AB street"
+        );
+
+        assertBikePath(
+                E, E1,
+                "null - 0 / 0.0 - null",
+                "🚲WALK - 20 / 100.0 - EF street",
+                "null - 0 / 1.0 - E1"
+        );
+    }
+
+    // A cost should be applied, since a mounting / dismounting takes place when entering the street network.
+    @Test
+    public void testPathwayBiking() {
+        assertPath(
+                E, S2,
+                StreetMode.BIKE,
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 5 / 10.0 - EF street",
+                        "null - 0 / 1.0 - E1",
+                        "🚲WALK - 160 / 1300.0 - E1S2 pathway"
+                ),
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 105 / 1010.0 - EF street",
+                        "null - 0 / 1.0 - E1",
+                        "🚲WALK - 60 / 300.0 - E1S2 pathway"
+                )
+        );
+    }
+
+    @Test
+    public void testPathwayBikeWalking() {
+        EF.setPermission(StreetTraversalPermission.PEDESTRIAN);
+
+        assertBikePath(
+                E, S2,
+                "null - 0 / 0.0 - null",
+                "🚲WALK - 20 / 100.0 - EF street",
+                "null - 0 / 1.0 - E1",
+                "🚲WALK - 60 / 300.0 - E1S2 pathway"
+        );
+    }
+
+    @Test
+    public void testPathwayWalking() {
+        assertWalkPath(
+                E, S2,
+                "null - 0 / 0.0 - null",
+                "WALK - 10 / 20.0 - EF street",
+                "null - 0 / 1.0 - E1",
+                "WALK - 60 / 120.0 - E1S2 pathway"
+        );
+    }
+
+    // A cost should be applied when dismounting bike only.
+    @Test
+    public void testElevatorWalking() {
+        assertWalkPath(
+                C, Q,
+                "null - 0 / 0.0 - null",
+                "WALK - 10 / 20.0 - CD street",
+                "null - 0 / 1.0 - null",
+                "WALK - 90 / 90.0 - Elevator",
+                "WALK - 20 / 20.0 - null",
+                "WALK - 0 / 1.0 - L-Q",
+                "null - 0 / 1.0 - null"
+        );
+    }
+
+    // No cost is added since no mounting / dismounting takes place
+    @Test
+    public void testElevatorBikeWalking() {
+        CD.setPermission(StreetTraversalPermission.PEDESTRIAN);
+
+        assertBikePath(
+                C, Q,
+                "null - 0 / 0.0 - null",
+                "🚲WALK - 20 / 100.0 - CD street",
+                "null - 0 / 1.0 - null",
+                "🚲WALK - 90 / 90.0 - Elevator",
+                "🚲WALK - 20 / 20.0 - null",
+                "🚲WALK - 0 / 1.0 - L-Q",
+                "null - 0 / 1.0 - null"
+        );
+    }
+
+    @Test
+    public void testElevatorBiking() {
+        assertPath(
+                C, Q, StreetMode.BIKE,
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 5 / 10.0 - CD street",
+                        "null - 0 / 1.0 - null",
+                        "🚲WALK - 190 / 1090.0 - Elevator",
+                        "🚲WALK - 20 / 20.0 - null",
+                        "🚲WALK - 0 / 1.0 - L-Q",
+                        "null - 0 / 1.0 - null"
+                ),
+                List.of(
+                        "null - 0 / 0.0 - null",
+                        "BICYCLE - 105 / 1010.0 - CD street",
+                        "null - 0 / 1.0 - null",
+                        "🚲WALK - 90 / 90.0 - Elevator",
+                        "🚲WALK - 20 / 20.0 - null",
+                        "🚲WALK - 0 / 1.0 - L-Q",
+                        "null - 0 / 1.0 - null"
+                )
+        );
+    }
+
+    private void assertBikePath(Vertex fromVertex, Vertex toVertex, String... descriptor) {
+        assertPath(fromVertex, toVertex, StreetMode.BIKE, List.of(descriptor), List.of(descriptor));
+    }
+
+    private void assertWalkPath(Vertex fromVertex, Vertex toVertex, String... descriptor) {
+        assertPath(fromVertex, toVertex, StreetMode.WALK, List.of(descriptor), List.of(descriptor));
+    }
+
+    private void assertPath(
+            Vertex fromVertex,
+            Vertex toVertex,
+            StreetMode streetMode,
+            List<String> expectedDepartAt,
+            List<String> expectedArriveBy
+    ) {
+        List<String> departAt =
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, streetMode, false);
+        List<String> arriveBy =
+                runStreetSearchAndCreateDescriptor(fromVertex, toVertex, streetMode, true);
+
+        assertEquals(expectedDepartAt, departAt, "departAt");
+        assertEquals(expectedArriveBy, arriveBy, "arriveBy");
+    }
+
+    private List<String> runStreetSearchAndCreateDescriptor(
+            Vertex fromVertex,
+            Vertex toVertex,
+            StreetMode streetMode,
+            boolean arriveBy
+    ) {
+        var options = new RoutingRequest();
+        options.bikeSwitchTime = 100;
+        options.bikeSwitchCost = 1000;
+        options.walkSpeed = 10;
+        options.bikeSpeed = 20;
+        options.bikeWalkingSpeed = 5;
+        options.arriveBy = arriveBy;
+
+        var bikeOptions = options.getStreetSearchRequest(streetMode);
+        bikeOptions.setRoutingContext(graph, fromVertex, toVertex);
+
+        var tree = new AStar().getShortestPathTree(bikeOptions);
+        var path = tree.getPath(
+                arriveBy ? fromVertex : toVertex,
+                false
+        );
+
+        if (path == null) {
+            return null;
+        }
+
+        return path.states.stream()
+                .map(s -> String.format(
+                        "%s%s - %s / %s - %s",
+                        s.getBackMode() != null && s.isBackWalkingBike() ? "🚲" : "",
+                        s.getBackMode(),
+                        s.getTimeDeltaSeconds(),
+                        s.getBackEdge() != null
+                                ? ((double) Math.round(s.getWeightDelta() * 10)) / 10
+                                : 0.0,
+                        s.getBackEdge() != null
+                                ? s.getBackEdge().getName()
+                                : null
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/CarPickupTest.java
@@ -121,8 +121,8 @@ public class CarPickupTest extends GraphRoutingTest {
         // and the path can't be traversed by car.
         assertPath(
                 A, B,
-                "null - IN_CAR - null, WALK - WALK_FROM_DROP_OFF - AB street",
-                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - AB street"
+                "null - WALK_TO_PICKUP - null, WALK - WALK_TO_PICKUP - AB street",
+                "null - WALK_FROM_DROP_OFF - null, WALK - WALK_FROM_DROP_OFF - AB street"
         );
     }
 

--- a/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
+++ b/src/test/java/org/opentripplanner/routing/algorithm/TurnCostTest.java
@@ -94,7 +94,7 @@ public class TurnCostTest {
         proto.walkSpeed = 1.0;
         proto.bikeSpeed = 1.0;
         proto.turnReluctance = (1.0);
-        proto.setWalkReluctance(1.0);
+        proto.setNonTransitReluctance(1.0);
         proto.stairsReluctance = (1.0);
         
         // Turn costs are all 0 by default.

--- a/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
+++ b/src/test/java/org/opentripplanner/routing/edgetype/TestTriangle.java
@@ -51,7 +51,7 @@ public class TestTriangle extends TestCase {
         RoutingRequest options = new RoutingRequest(TraverseMode.BICYCLE);
         options.optimize = BicycleOptimizeType.TRIANGLE;
         options.bikeSpeed = 6.0;
-        options.walkReluctance = 1;
+        options.setNonTransitReluctance(1);
 
         options.setBikeTriangleSafetyFactor(0);
         options.setBikeTriangleSlopeFactor(0);
@@ -59,7 +59,7 @@ public class TestTriangle extends TestCase {
         State startState = new State(v1, options);
         State result = testStreet.traverse(startState);
         double timeWeight = result.getWeight();
-        double expectedTimeWeight = slopeSpeedLength / options.getSpeed(TraverseMode.BICYCLE);
+        double expectedTimeWeight = slopeSpeedLength / options.getSpeed(TraverseMode.BICYCLE, false);
         assertTrue(Math.abs(expectedTimeWeight - timeWeight) < 0.00001);
 
         options.setBikeTriangleSafetyFactor(0);
@@ -68,10 +68,10 @@ public class TestTriangle extends TestCase {
         startState = new State(v1, options);
         result = testStreet.traverse(startState);
         double slopeWeight = result.getWeight();
-        double expectedSlopeWeight = slopeWorkLength / options.getSpeed(TraverseMode.BICYCLE);
+        double expectedSlopeWeight = slopeWorkLength / options.getSpeed(TraverseMode.BICYCLE, false);
         assertTrue(Math.abs(expectedSlopeWeight - slopeWeight) < 0.00001);
-        assertTrue(length * 1.5 / options.getSpeed(TraverseMode.BICYCLE) < slopeWeight);
-        assertTrue(length * 1.5 * 10 / options.getSpeed(TraverseMode.BICYCLE) > slopeWeight);
+        assertTrue(length * 1.5 / options.getSpeed(TraverseMode.BICYCLE, false) < slopeWeight);
+        assertTrue(length * 1.5 * 10 / options.getSpeed(TraverseMode.BICYCLE, false) > slopeWeight);
 
         options.setBikeTriangleSafetyFactor(1);
         options.setBikeTriangleSlopeFactor(0);
@@ -80,7 +80,9 @@ public class TestTriangle extends TestCase {
         result = testStreet.traverse(startState);
         double safetyWeight = result.getWeight();
         double slopeSafety = costs.slopeSafetyCost;
-        double expectedSafetyWeight = (trueLength * 0.74 + slopeSafety) / options.getSpeed(TraverseMode.BICYCLE);
+        double expectedSafetyWeight = (trueLength * 0.74 + slopeSafety) / options.getSpeed(TraverseMode.BICYCLE,
+                false
+        );
         assertTrue(Math.abs(expectedSafetyWeight - safetyWeight) < 0.00001);
 
         final double ONE_THIRD = 1/3.0;

--- a/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/SimpleConcreteEdge.java
@@ -25,7 +25,7 @@ public class SimpleConcreteEdge extends Edge {
     public State traverse(State s0) {
         double d = getDistanceMeters();
         TraverseMode mode = s0.getNonTransitMode();
-        int t = (int) (d / s0.getOptions().getSpeed(mode));
+        int t = (int) (d / s0.getOptions().getSpeed(mode, false));
         StateEditor s1 = s0.edit(this);
         s1.incrementTimeInSeconds(t);
         s1.incrementWeight(d);

--- a/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
+++ b/src/test/java/org/opentripplanner/routing/graph/TemporaryConcreteEdge.java
@@ -32,7 +32,7 @@ public class TemporaryConcreteEdge extends Edge implements TemporaryEdge {
     public State traverse(State s0) {
         double d = getDistanceMeters();
         TraverseMode mode = s0.getNonTransitMode();
-        int t = (int) (d / s0.getOptions().getSpeed(mode));
+        int t = (int) (d / s0.getOptions().getSpeed(mode, false));
         StateEditor s1 = s0.edit(this);
         s1.incrementTimeInSeconds(t);
         s1.incrementWeight(d);


### PR DESCRIPTION
Several semi-related fixes:
 * a cost is added for car pickup / dropoff (taxi mode) -- this was needed for tests to pass in a determenistic manner
 * `bikeReluctance`, `bikeWalkingReluctance`, `carReluctance` parameters are added
 * extend bike-walking handling to elevators and pathways
 * corrections to the leg-splitting logic