### PR TITLE
LegacyGraphQLApi: expose VehicleParking opening and fee hours

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLVehicleParkingImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLVehicleParkingImpl.java
@@ -5,6 +5,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.opentripplanner.ext.legacygraphqlapi.generated.LegacyGraphQLDataFetchers;
 import org.opentripplanner.routing.vehicle_parking.VehicleParking;
+import org.opentripplanner.util.I18NString;
 
 public class LegacyGraphQLVehicleParkingImpl implements LegacyGraphQLDataFetchers.LegacyGraphQLVehicleParking {
     @Override
@@ -22,7 +23,7 @@ public class LegacyGraphQLVehicleParkingImpl implements LegacyGraphQLDataFetcher
 
     @Override
     public DataFetcher<String> name() {
-        return environment -> getSource(environment).getName().toString();
+        return environment -> getSource(environment).getName().toString(environment.getLocale());
     }
 
     @Override
@@ -59,7 +60,25 @@ public class LegacyGraphQLVehicleParkingImpl implements LegacyGraphQLDataFetcher
     public DataFetcher<String> note() {
         return environment -> {
             var note = getSource(environment).getNote();
-            return note != null ? note.toString() : null;
+            return note != null ? note.toString(environment.getLocale()) : null;
+        };
+    }
+
+    @Override
+    public DataFetcher<String> feeHours() {
+        return environment -> {
+            var feeHours = getSource(environment).getFeeHours();
+            return feeHours instanceof I18NString
+                    ? ((I18NString) feeHours).toString(environment.getLocale()) : null;
+        };
+    }
+
+    @Override
+    public DataFetcher<String> openingHours() {
+        return environment -> {
+            var openingHours = getSource(environment).getOpeningHours();
+            return openingHours instanceof I18NString
+                    ? ((I18NString) openingHours).toString(environment.getLocale()) : null;
         };
     }
 

--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/generated/LegacyGraphQLDataFetchers.java
@@ -72,6 +72,8 @@ public class LegacyGraphQLDataFetchers {
     public DataFetcher<String> imageUrl();
     public DataFetcher<Iterable<String>> tags();
     public DataFetcher<String> note();
+    public DataFetcher<String> feeHours();
+    public DataFetcher<String> openingHours();
     public DataFetcher<VehicleParking.VehicleParkingState> state();
     public DataFetcher<Boolean> bicyclePlaces();
     public DataFetcher<Boolean> anyCarPlaces();

--- a/src/ext/resources/legacygraphqlapi/schema.graphqls
+++ b/src/ext/resources/legacygraphqlapi/schema.graphqls
@@ -267,6 +267,10 @@ type VehicleParking implements Node & PlaceInterface {
 
     note: String
 
+    feeHours: String
+
+    openingHours: String
+
     state: VehicleParkingState
 
     bicyclePlaces: Boolean


### PR DESCRIPTION
This adds the `openingHours` and `feeHours` for vehicle parkings to the GraphQL API. The request locale is also used when converting `I18NStrings` for the API.