### PR TITLE
Add ParkAndRideDirectBikeItineraryFilter

### DIFF
--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/ItineraryFilterChainBuilder.java
@@ -12,6 +12,7 @@ import org.opentripplanner.routing.algorithm.filterchain.filters.NonTransitGener
 import org.opentripplanner.routing.algorithm.filterchain.filters.OtpDefaultSortOrder;
 import org.opentripplanner.routing.algorithm.filterchain.filters.RemoveBikerentalWithMostlyWalkingFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.FlexOnlyToDestinationFilter;
+import org.opentripplanner.routing.algorithm.filterchain.filters.ParkAndRideDirectBikeItineraryFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.RemoveParkAndRideWithMostlyWalkingFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.RemoveTransitIfStreetOnlyIsBetterFilter;
 import org.opentripplanner.routing.algorithm.filterchain.filters.RemoveWalkOnlyFilter;
@@ -49,6 +50,7 @@ public class ItineraryFilterChainBuilder {
     private Instant latestDepartureTimeLimit = null;
     private Consumer<Itinerary> maxLimitReachedSubscriber;
     private double minBikeParkingDistance = NOT_SET;
+    private boolean removeBikeOnlyParkAndRideItineraries;
 
 
     /**
@@ -225,6 +227,11 @@ public class ItineraryFilterChainBuilder {
         return this;
     }
 
+    public ItineraryFilterChainBuilder withRemoveBikeOnlyParkAndRideItineraries(boolean enabled) {
+        this.removeBikeOnlyParkAndRideItineraries = enabled;
+        return this;
+    }
+
     public ItineraryFilter build() {
         List<ItineraryFilter> filters = new ArrayList<>();
 
@@ -299,6 +306,10 @@ public class ItineraryFilterChainBuilder {
 
             if (minBikeParkingDistance != NOT_SET) {
                 filters.add(new RemoveBikeParkWithShortBikingFilter(minBikeParkingDistance));
+            }
+
+            if (removeBikeOnlyParkAndRideItineraries) {
+                filters.add(new ParkAndRideDirectBikeItineraryFilter());
             }
         }
 

--- a/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/ParkAndRideDirectBikeItineraryFilter.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/filterchain/filters/ParkAndRideDirectBikeItineraryFilter.java
@@ -1,0 +1,33 @@
+package org.opentripplanner.routing.algorithm.filterchain.filters;
+
+import org.opentripplanner.model.plan.Itinerary;
+import org.opentripplanner.routing.algorithm.filterchain.ItineraryFilter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.opentripplanner.routing.core.TraverseMode.BICYCLE;
+
+public class ParkAndRideDirectBikeItineraryFilter implements ItineraryFilter {
+
+  @Override
+  public String name() {
+    return "park-and-ride-direct-bike-itinerary-filter";
+  }
+
+  @Override
+  public List<Itinerary> filter(List<Itinerary> itineraries) {
+    return itineraries.stream()
+        .filter(this::filterBikeOnlyParkAndRideItineraries)
+        .collect(Collectors.toList());
+  }
+
+  private boolean filterBikeOnlyParkAndRideItineraries(Itinerary itinerary) {
+    return !itinerary.legs.stream().allMatch(leg -> leg.mode == BICYCLE || leg.walkingBike);
+  }
+
+  @Override
+  public boolean removeItineraries() {
+    return true;
+  }
+}

--- a/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingRequestToFilterChainMapper.java
+++ b/src/main/java/org/opentripplanner/routing/algorithm/mapping/RoutingRequestToFilterChainMapper.java
@@ -56,6 +56,10 @@ public class RoutingRequestToFilterChainMapper {
       builder.withMinBikeParkingDistance(p.minBikeParkingDistance);
     }
 
+    if (request.modes.contains(StreetMode.CAR_TO_PARK) && request.modes.directMode == StreetMode.BIKE) {
+      builder.withRemoveBikeOnlyParkAndRideItineraries(true);
+    }
+
     var flexWasRequested = request.modes.egressMode == StreetMode.FLEXIBLE ||
             request.modes.directMode == StreetMode.FLEXIBLE;
     builder


### PR DESCRIPTION
This adds a filter to remove the direct `BIKE` itinerary when planning `PARK_AND_RIDE` trips (#118)