### PR TITLE
Excludes disabled freefloating vehicles from vectortiles

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/vehiclerental/VehicleRentalLayerBuilder.java
@@ -41,6 +41,7 @@ public class VehicleRentalLayerBuilder extends LayerBuilder<VehicleRentalPlace> 
     if (service == null) {return List.of();}
     return service.getVehicleRentalPlaces()
         .stream()
+        .filter(vehicleRentalPlace -> !vehicleRentalPlace.isFloatingVehicle() || vehicleRentalPlace.isAllowPickup())
         .map(vehicleRentalStation -> {
           Coordinate coordinate = new Coordinate(vehicleRentalStation.getLongitude(), vehicleRentalStation.getLatitude());
           Point point = GeometryUtils.getGeometryFactory().createPoint(coordinate);


### PR DESCRIPTION
This PR excludes disabled freefloating vehicles (no pickup allowed) from vector tiles.
Some sharing providers disable vehicles if their remaining energy is below a minimum level.
