### PR TITLE
Fix missing MainModeEnum for CARPOOL

### DIFF
--- a/src/main/java/org/opentripplanner/api/parameter/ApiRequestMode.java
+++ b/src/main/java/org/opentripplanner/api/parameter/ApiRequestMode.java
@@ -30,7 +30,7 @@ public enum ApiRequestMode {
     TROLLEYBUS(fromMainModeEnum(TransitMode.TROLLEYBUS)),
     MONORAIL(fromMainModeEnum(TransitMode.MONORAIL)),
     FLEX(),
-    CARPOOL();
+    CARPOOL(fromMainModeEnum(TransitMode.CARPOOL));
 
     private final Set<AllowedTransitMode> transitModes;
 


### PR DESCRIPTION
### Summary
This fix adds the missing MainModeEnum for CARPOOL mode

