### PR TITLE
Handle I18NString stop name in VectorTiles

### DIFF
--- a/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
+++ b/src/ext-test/java/org/opentripplanner/ext/vectortiles/StopsLayerTest.java
@@ -1,0 +1,60 @@
+package org.opentripplanner.ext.vectortiles;
+
+import ch.poole.openinghoursparser.OpeningHoursParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.opentripplanner.ext.vectortiles.layers.stops.DigitransitStopPropertyMapper;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.Stop;
+import org.opentripplanner.model.WgsCoordinate;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.graph.GraphIndex;
+import org.opentripplanner.routing.vertextype.TransitStopVertex;
+import org.opentripplanner.util.NonLocalizedString;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class StopsLayerTest {
+
+    private Stop stop;
+
+    @Before
+    public void setUp() throws OpeningHoursParseException {
+        stop =  new Stop(
+                new FeedScopedId("F", "id"),
+                new NonLocalizedString("name"),
+                "code",
+                "desc",
+                new WgsCoordinate(50, 10),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Test
+    public void digitransitVehicleParkingPropertyMapperTest() {
+        Graph graph = mock(Graph.class);
+        graph.index=mock(GraphIndex.class);
+
+        DigitransitStopPropertyMapper mapper = DigitransitStopPropertyMapper.create(graph);
+        Map<String, Object> map = new HashMap<>();
+        mapper.map(new TransitStopVertex(graph, stop, null)).forEach(o -> map.put(o.first, o.second));
+
+        assertEquals("F:id", map.get("gtfsId"));
+        assertEquals("name", map.get("name"));
+        assertEquals("desc", map.get("desc"));
+
+
+
+
+    }
+}

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stations/DigitransitStationPropertyMapper.java
@@ -30,7 +30,8 @@ public class DigitransitStationPropertyMapper extends PropertyMapper<Station> {
 
     return List.of(
       new T2<>("gtfsId", station.getId().toString()),
-      new T2<>("name", station.getName()),
+      // Name is I18NString now, we return default name
+      new T2<>("name", station.getName().toString()),
       new T2<>("type", childStops
         .stream()
         .flatMap(stop -> graph.index.getPatternsForStop(stop).stream())

--- a/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
+++ b/src/ext/java/org/opentripplanner/ext/vectortiles/layers/stops/DigitransitStopPropertyMapper.java
@@ -52,7 +52,8 @@ public class DigitransitStopPropertyMapper extends PropertyMapper<TransitStopVer
 
     return List.of(
       new T2<>("gtfsId", stop.getId().toString()),
-      new T2<>("name", stop.getName()),
+      // Name is I18NString now, we return default name
+      new T2<>("name", stop.getName().toString()),
       new T2<>("code", stop.getCode()),
       new T2<>("platform", stop.getPlatformCode()),
       new T2<>("desc", stop.getDescription()),


### PR DESCRIPTION
This PR converts I18NString stop / station names to Strings, as only primitves and string are supported as vector tile values.

Note: Another option might be to handle this once in vectortiles.PropertyMapper, e.g. like this:

```java
        Object value = e.second;
        if (value != null && !MvtValue.isValidPropValue(value)) {
          value = value.toString();
        }
```