### PR TITLE
Return complete feed id for GraphQL CarPark entity

### DIFF
--- a/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
+++ b/src/ext/java/org/opentripplanner/ext/legacygraphqlapi/datafetchers/LegacyGraphQLCarParkImpl.java
@@ -10,7 +10,7 @@ public class LegacyGraphQLCarParkImpl implements LegacyGraphQLDataFetchers.Legac
 
   @Override
   public DataFetcher<String> carParkId() {
-    return environment -> getSource(environment).getId().getId();
+    return environment -> getSource(environment).getId().toString();
   }
 
   @Override


### PR DESCRIPTION
This returns the full, prefixed feed-scoped ID for the `CarPark` entity.